### PR TITLE
Made the page after login responsive and fixed the card issue with login page

### DIFF
--- a/src/components/Auth/LoggedIn/LoggedIn.react.js
+++ b/src/components/Auth/LoggedIn/LoggedIn.react.js
@@ -12,7 +12,9 @@ import iOS from '../../images/ios.png'
 import android from '../../images/android1.png'
 import web from '../../images/network-icon.png'
 import cms from '../../images/edit-icon-png-24.png'
-
+import Grid from 'react-bootstrap/lib/Grid';
+import Row from 'react-bootstrap/lib/Row';
+import Col from 'react-bootstrap/lib/Col';
 const ListMenu = () => (
           <IconMenu className='IconMenu'
                       tooltip="Options"
@@ -82,7 +84,10 @@ class LoggedIn extends Component {
           />
         </div>
         <div id="parent">
-           <div className="child1">
+        <Grid>
+        <Row>
+            <Col xs={12} sm={6} style={{'float':'left'}}>
+                { <div className="child1">
             <Link to="/settings">
               <Paper style={style} zDepth={1} circle={true}>
               <img style={{margin: '25px 10px', height: '70%'}} src={iOS}
@@ -92,8 +97,10 @@ class LoggedIn extends Component {
               <div style={heading1}>
                 <h2>iOS</h2>
               </div>
-	         </div>
-           <div className="child2">
+	         </div>}
+            </Col>
+            <Col xs={12} sm={6} style={{'float':'left'}}>
+                {<div className="child2">
             <Link to="/settings">
               <Paper style={style} zDepth={1} circle={true}>
               <img style={{margin: '30', height: '70%'}} src={android}
@@ -103,8 +110,10 @@ class LoggedIn extends Component {
               <div style={heading2}>
                 <h2>Android</h2>
               </div>
-	         </div>
-           <div className="child3">
+	         </div>}
+            </Col>
+            <Col xs={12} sm={6} style={{'float':'left'}}>
+                {<div className="child3">
             <Link to="/settings">
               <Paper style={style} zDepth={1} circle={true}>
               <img style={{margin: '35'}} src={web}
@@ -114,8 +123,10 @@ class LoggedIn extends Component {
               <div style={heading3}>
                 <h2>Web</h2>
               </div>
-	         </div>
-           <div className="child4">
+	         </div>}
+            </Col>
+            <Col xs={12} sm={6} style={{'float':'left'}}>
+                {<div className="child4">
             <Link to="/settings">
               <Paper style={style} zDepth={1} circle={true}>
               <img style={{margin: '35', height: '65%'}} src={cms}
@@ -125,9 +136,12 @@ class LoggedIn extends Component {
               <div style={heading3}>
                 <h2>CMS</h2>
               </div>
-	         </div>
+	         </div>}
+            </Col>
+        </Row>
+        </Grid>
         </div>
-    </div>
+      </div>
     )
   }
 }

--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -200,7 +200,8 @@ class Login extends Component {
 
 		const styles = {
 			'margin': '60px auto',
-            'width': '100%',
+			'width':'80%',
+			'max-width':'400px',
             'padding': '20px',
             'textAlign': 'center',
 			'box-shadow': ['rgba(0, 0, 0, 0.12) 0px 1px 6px', 'rgba(0, 0, 0, 0.12) 0px 1px 4px']


### PR DESCRIPTION
Fixes #204 
Fixes #200 
Changes: Made the page after login responsive (i.e on decreasing browser size the icons don't overlap).
Surge Deployment Link: http://responsive-design-02.surge.sh/
Screenshots for the change:
![screen shot 2018-03-07 at 10 08 45 pm](https://user-images.githubusercontent.com/31013104/37104924-e823cace-2253-11e8-8e47-85dcf8b236d4.png)
![screen shot 2018-03-07 at 10 08 59 pm](https://user-images.githubusercontent.com/31013104/37104934-ee95b2f0-2253-11e8-8a27-3ad0312bcc11.png)
![screen shot 2018-03-08 at 7 53 44 pm](https://user-images.githubusercontent.com/31013104/37155771-2b2e603e-230a-11e8-9802-515990951c55.png)
![screen shot 2018-03-08 at 7 53 52 pm](https://user-images.githubusercontent.com/31013104/37155782-317ee490-230a-11e8-8afc-69dbb63e5315.png)
