### PR TITLE
Fixes #247: Correct login/logout menuItem as per session

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.js
+++ b/src/components/StaticAppBar/StaticAppBar.js
@@ -17,6 +17,7 @@ import Chat from 'material-ui/svg-icons/communication/chat';
 import Extension from 'material-ui/svg-icons/action/extension';
 import Settings from 'material-ui/svg-icons/action/settings';
 import Exit from 'material-ui/svg-icons/action/exit-to-app';
+import LoginIcon from 'material-ui/svg-icons/action/account-circle';
 
 const cookies = new Cookies();
 
@@ -58,9 +59,18 @@ const ListMenu = () => (
       ]}
       rightIcon={<Settings/>}
       />
-    <MenuItem primaryText="Logout"
-      containerElement={<Link to="/logout" />}
-      rightIcon={<Exit />}/>
+    {
+      cookies.get('loggedIn') ?
+        (
+          <MenuItem primaryText="Logout"
+            containerElement={<Link to="/logout" />}
+            rightIcon={<Exit />}/>):
+        (
+          <MenuItem primaryText="Login"
+            containerElement={<Link to="/" />}
+            rightIcon={<LoginIcon />}/>)
+
+    }
   </IconMenu>
 );
 


### PR DESCRIPTION
Fixes #247 

Changes: Use cookies to check whether the user is logged in and display the login/logout menuItem accordingly.

Surge Deployment Link: http://plain-spark.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/40672022-33d21bb0-638b-11e8-89a1-5e2029b62cf3.png)
![image](https://user-images.githubusercontent.com/21009455/40672034-3f12a30a-638b-11e8-97e6-54c214b92a4d.png)
