### PR TITLE
Fix bug on login page when password field is empty

### DIFF
--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -156,7 +156,7 @@ class Login extends Component {
 		else {
 			this.passwordErrorMessage = '';
 		}
-		if (!state.emailError && !state.passwordError) {
+		if (!state.emailError && !state.passwordError && this.state.password != '') {
 			state.validForm = true;
 		}
 		else {


### PR DESCRIPTION
Fixes #250 

Changes: Fixed bug on login page. Now login button will enable only if both email and password field are filled and follow the rules correctly.

Surge Deployment Link: http://stupid-owl.surge.sh/

Screenshots for the change:
Earlier
![example](https://user-images.githubusercontent.com/30981465/40770363-18d495ce-64d8-11e8-9880-a88c2e2e74c3.png)
Now
![example1](https://user-images.githubusercontent.com/30981465/40770373-1d7b525c-64d8-11e8-9773-153de8891826.png)
