### PR TITLE
Settings is only shown when logged in

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.js
+++ b/src/components/StaticAppBar/StaticAppBar.js
@@ -49,16 +49,20 @@ const ListMenu = () => (
           rightIcon={<Extension/>}/>):
           null
     }
-   <MenuItem
-      primaryText="Settings"
-      menuItems={[
-        <MenuItem key="1" primaryText="Change Password"
-        containerElement={<Link to="/changepassword" />} />,
-        <MenuItem key="2" primaryText="Delete Account"
-        containerElement={<Link to="/delete-account" />} />
-      ]}
-      rightIcon={<Settings/>}
-      />
+    {
+      cookies.get('loggedIn') ?
+        (<MenuItem
+          primaryText="Settings"
+          menuItems={[
+            <MenuItem key="1" primaryText="Change Password"
+            containerElement={<Link to="/changepassword" />} />,
+            <MenuItem key="2" primaryText="Delete Account"
+            containerElement={<Link to="/delete-account" />} />
+          ]}
+          rightIcon={<Settings/>}
+         />):
+          null
+    }
     {
       cookies.get('loggedIn') ?
         (


### PR DESCRIPTION
Fixes #253 

Changes: Settings is only shown when logged in

Surge Deployment Link: http://abandoned-camera.surge.sh/

Screenshots for the change:
![bug3](https://user-images.githubusercontent.com/30981465/40846199-8673d866-65d6-11e8-89de-6d112d89762a.png)
