### PR TITLE
Deploy PRs on surge automatically

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,6 +2,6 @@ Fixes #[Add issue number here. If you do not solve the issue entirely, please ch
 
 Changes: [Add here what changes were made in this issue and if possible provide links.]
 
-Surge Deployment Link: [Add here the link where you changes can be seen]
+Surge Deployment Link: https://pr-${TRAVIS_PULL_REQUEST}-fossasia-susi-accounts.surge.sh
 
 Screenshots for the change:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   - npm run test
 
 after_success:
+  - bash ./surge_deploy.sh
   - bash ./deploy.sh
 
 cache:
@@ -24,4 +25,4 @@ cache:
 # safelist
 branches:
   only:
-  - master  
+  - master

--- a/surge_deploy.sh
+++ b/surge_deploy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    echo "Not a PR. Skipping surge deployment"
+    exit 0
+fi
+
+npm i -g surge
+# Actual building and setup of current push or PR.
+npm install
+npm run build
+rm -rf node_modules/
+cp build/index.html build/404.html
+
+export SURGE_LOGIN=fossasiasusiaccounts@example.com
+# Token of a dummy account.
+export SURGE_TOKEN=08eb55bcd3fa5ab726365bbee2b3a5c6
+
+export DEPLOY_DOMAIN=https://pr-${TRAVIS_PULL_REQUEST}-fossasia-susi-accounts.surge.sh
+surge --project ./build --domain $DEPLOY_DOMAIN;


### PR DESCRIPTION
Fixes #282 

Changes: Now PRs will be deployed automatically to surge after tests passes.

Surge Deployment Link: [Add here the link where you changes can be seen]
