### PR TITLE
Add basic admin page

### DIFF
--- a/src/components/Admin/Admin.css
+++ b/src/components/Admin/Admin.css
@@ -1,0 +1,35 @@
+.SettingsTab{
+    padding: 0px;
+    width: auto;
+    margin: 0 auto;
+}
+.heading{
+    height: 150px;
+}
+.tabs{
+    margin-top: -10px;
+    padding-left: 25px;
+    padding-right: 30px;
+}
+.containerDiv{
+    background-color: #ffffff;
+}
+
+.container{
+    margin-top: 30px;
+    margin-left: 20px;
+    margin-right: 20px;
+    background-color: #ffffff;
+}
+
+.h1{
+    padding-top: 65px;
+    font-size: 40px;
+    margin-left: 21px;
+}
+
+.containerPaper{
+    margin-top: -68px;
+    margin-left: 60px;
+    margin-right: 40px;
+}

--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -1,0 +1,127 @@
+import React, { Component } from 'react';
+import './Admin.css';
+import StaticAppBar from '../StaticAppBar/StaticAppBar.js';
+import Dialog from 'material-ui/Dialog';
+import $ from 'jquery';
+import Cookies from 'universal-cookie';
+import FlatButton from 'material-ui/FlatButton';
+import PropTypes from 'prop-types';
+import Paper from 'material-ui/Paper';
+import Tabs from 'antd/lib/tabs';
+import ListUser from './ListUser/ListUser';
+import 'antd/lib/tabs/style/index.css';
+// import ListUser from './ListUser/ListUser';
+
+const cookies = new Cookies();
+
+const TabPane = Tabs.TabPane;
+
+class Admin extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tabPosition: 'top',
+      showNotAdminDialog: false,
+    };
+  }
+
+  componentDidMount() {
+    if (!cookies.get('loggedIn')) {
+      this.props.history.push('/');
+      window.location.reload();
+    }
+    let url;
+    url =
+      'https://api.susi.ai/aaa/showAdminService.json?access_token=' +
+      cookies.get('loggedIn');
+    $.ajax({
+      url: url,
+      dataType: 'jsonp',
+      jsonpCallback: 'pyfw',
+      jsonp: 'callback',
+      crossDomain: true,
+      success: function(response) {
+        // console.log(response.showAdmin);
+        if (response.showAdmin !== true) {
+          this.setState({
+            showNotAdminDialog: true,
+          });
+        } else {
+          this.setState({
+            showNotAdminDialog: false,
+          });
+        }
+      }.bind(this),
+      error: function(errorThrown) {
+        this.setState({
+          showNotAdminDialog: false,
+        });
+        console.log(errorThrown);
+      }.bind(this),
+    });
+  }
+
+  handleClose = () => {
+    this.props.history.push('/');
+    window.location.reload();
+  };
+
+  render() {
+    const actions = [
+      <FlatButton
+        key={1}
+        label="Ok"
+        primary={true}
+        onTouchTap={this.handleClose}
+      />,
+    ];
+
+    const tabStyle = {
+      width: '100%',
+      animated: false,
+      textAlign: 'center',
+      display: 'inline-block',
+    };
+
+    return (
+      <div>
+        <div className="heading">
+          <StaticAppBar {...this.props} />
+          <h1 className="h1">SUSI.AI Admin Panel</h1>
+        </div>
+        <div>
+          <Dialog
+            title="Permission Denied"
+            actions={actions}
+            modal={true}
+            open={this.state.showNotAdminDialog}
+          >
+            You do not have permissions to access this page!! :(
+          </Dialog>
+        </div>
+        <div className="tabs">
+          <Paper style={tabStyle} zDepth={0}>
+            <Tabs tabPosition={this.state.tabPosition} animated={false}>
+              <TabPane tab="Admin" key="1">
+                Tab for Admin Content
+              </TabPane>
+              <TabPane tab="Users" key="2">
+                <ListUser />
+              </TabPane>
+              <TabPane tab="Permissions" key="3">
+                Permission Content Tab
+              </TabPane>
+            </Tabs>
+          </Paper>
+        </div>
+      </div>
+    );
+  }
+}
+
+Admin.propTypes = {
+  history: PropTypes.object,
+};
+
+export default Admin;

--- a/src/components/Admin/ListUser/ListUser.css
+++ b/src/components/Admin/ListUser/ListUser.css
@@ -1,0 +1,11 @@
+.banner{
+    background-color: #f7f7f7;
+}
+.h1{
+    padding-top: 4%;
+    font-size: 50px;
+}
+.table{
+    margin-left: 30px;
+    margin-right: 30px;
+}

--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -1,0 +1,201 @@
+import React, { Component } from 'react';
+import './ListUser.css';
+import $ from 'jquery';
+import Cookies from 'universal-cookie';
+import Table from 'antd/lib/table';
+import 'antd/lib/table/style/index.css';
+
+const cookies = new Cookies();
+
+const columns = [
+  {
+    title: 'S.No.',
+    dataIndex: 'serialNum',
+    sorter: false,
+    width: '5%',
+  },
+  {
+    title: 'Email ID',
+    dataIndex: 'email',
+    sorter: false,
+    width: '25%',
+  },
+  {
+    title: 'Activation Status',
+    dataIndex: 'confirmed',
+    sorter: false,
+    width: '15%',
+  },
+  {
+    title: 'Signup',
+    dataIndex: 'signup',
+    width: '15%',
+  },
+  {
+    title: 'Last Login',
+    dataIndex: 'lastLogin',
+    width: '15%',
+  },
+  {
+    title: 'IP of Last Login',
+    dataIndex: 'ipLastLogin',
+    width: '15%',
+  },
+  {
+    title: 'User Role',
+    dataIndex: 'userRole',
+    sorter: false,
+    width: '10%',
+  },
+];
+
+export default class ListUser extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      username: [],
+      data: [],
+      middle: '50',
+      pagination: {},
+      loading: false,
+    };
+  }
+
+  handleTableChange = (pagination, filters, sorter) => {
+    const pager = { ...this.state.pagination };
+    pager.current = pagination.current;
+    this.setState({
+      pagination: pager,
+    });
+    this.fetch({
+      results: pagination.pageSize,
+      page: pagination.current,
+      sortField: sorter.field,
+      sortOrder: sorter.order,
+      ...filters,
+    });
+  };
+
+  componentDidMount() {
+    const pagination = { ...this.state.pagination };
+    let url;
+    url =
+      'https://api.susi.ai/aaa/showAdminService.json?access_token=' +
+      cookies.get('loggedIn');
+    $.ajax({
+      url: url,
+      dataType: 'jsonp',
+      jsonpCallback: 'py',
+      jsonp: 'callback',
+      crossDomain: true,
+      success: function(response) {
+        // console.log(response.showAdmin);
+        if (response.showAdmin) {
+          let getPagesUrl =
+            'https://api.susi.ai/aaa/getUsers.json?access_token=' +
+            cookies.get('loggedIn') +
+            '&getUserCount=true';
+          $.ajax({
+            url: getPagesUrl,
+            dataType: 'jsonp',
+            jsonpCallback: 'pvsdu',
+            jsonp: 'callback',
+            crossDomain: true,
+            success: function(data) {
+              // console.log(data);
+              pagination.total = data.userCount;
+              pagination.pageSize = 50;
+              this.setState({
+                loading: false,
+                pagination,
+              });
+              // console.log(pagination);
+              this.fetch();
+            }.bind(this),
+            error: function(errorThrown) {
+              console.log(errorThrown);
+            },
+          });
+        } else {
+          console.log('Not allowed to access this page!');
+        }
+      }.bind(this),
+      error: function(errorThrown) {
+        console.log('Not allowed to access this page!');
+        console.log(errorThrown);
+      },
+    });
+  }
+
+  fetch = (params = {}) => {
+    let url;
+    let page;
+    if (params.page !== undefined) {
+      // console.log(params.page);
+      page = params.page;
+    } else {
+      page = 1;
+    }
+    url =
+      'https://api.susi.ai/aaa/getUsers.json?access_token=' +
+      cookies.get('loggedIn') +
+      '&page=' +
+      page;
+    $.ajax({
+      url: url,
+      dataType: 'jsonp',
+      jsonpCallback: 'pvsdu',
+      jsonp: 'callback',
+      crossDomain: true,
+      success: function(response) {
+        // console.log(response.users);
+        let userList = response.users;
+        let users = [];
+        userList.map((data, i) => {
+          let user = {
+            serialNum: ++i + (page - 1) * 50,
+            email: data.name,
+            confirmed: data.confirmed,
+            signup: data.signupTime,
+            lastLogin: data.lastLoginTime,
+            ipLastLogin: data.lastLoginIP,
+            userRole: data.userRole,
+          };
+
+          if (user.confirmed) {
+            user.confirmed = 'Activated';
+          } else {
+            user.confirmed = 'Not Activated';
+          }
+
+          users.push(user);
+          return 1;
+        });
+        // console.log(users);
+        this.setState({
+          data: users,
+        });
+      }.bind(this),
+      error: function(errorThrown) {
+        console.log(errorThrown);
+      },
+    });
+    // Read total count from server
+    // pagination.total = data.totalCount;
+  };
+
+  render() {
+    return (
+      <div className="table">
+        <Table
+          columns={columns}
+          rowKey={record => record.registered}
+          dataSource={this.state.data}
+          pagination={this.state.pagination}
+          loading={this.state.loading}
+          onChange={this.handleTableChange}
+        />
+      </div>
+    );
+  }
+}

--- a/src/components/StaticAppBar/StaticAppBar.js
+++ b/src/components/StaticAppBar/StaticAppBar.js
@@ -20,6 +20,7 @@ import Assessment from 'material-ui/svg-icons/action/assessment';
 import Settings from 'material-ui/svg-icons/action/settings';
 import Exit from 'material-ui/svg-icons/action/exit-to-app';
 import LoginIcon from 'material-ui/svg-icons/action/account-circle';
+import List from 'material-ui/svg-icons/action/list';
 import susiWhite from '../../images/susi-logo-white.png';
 import './StaticAppBar.css';
 
@@ -95,6 +96,13 @@ const ListMenu = () => (
           rightIcon={<Settings />}
         />
       ) : null}
+      {cookies.get('showAdmin') === true ? (
+        <MenuItem
+          primaryText="Admin"
+          rightIcon={<List />}
+          containerElement={<Link to="/admin" />}
+        />
+      ) : null}
       <MenuItem
         primaryText="About"
         href="http://chat.susi.ai/overview"
@@ -127,6 +135,28 @@ class StaticAppBar extends Component {
   };
 
   componentDidMount() {
+    $.ajax({
+      url:
+        'https://api.susi.ai' +
+        '/aaa/showAdminService.json?access_token=' +
+        cookies.get('loggedIn'),
+      dataType: 'jsonp',
+      jsonpCallback: 'pfns',
+      jsonp: 'callback',
+      crossDomain: true,
+      success: function(newResponse) {
+        let ShowAdmin = newResponse.showAdmin;
+        cookies.set('showAdmin', ShowAdmin);
+        this.setState({
+          showAdmin: ShowAdmin,
+        });
+        console.log(newResponse.showAdmin);
+      }.bind(this),
+      error: function(newErrorThrown) {
+        console.log(newErrorThrown);
+      },
+    });
+
     $.ajax({
       url:
         'https://api.susi.ai' +

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import ChangePassword from './components/Auth/ChangePassword/ChangePassword.reac
 import ResetPassword from './components/Auth/ResetPassword/ResetPassword.react';
 import DeleteAccount from './components/Auth/DeleteAccount/DeleteAccount.react';
 import Settings from './components/Settings/Settings.react';
+import Admin from './components/Admin/Admin.js';
 import VerifyAccount from './components/Auth/VerifyAccount/VerifyAccount.react';
 import Login from './components/Auth/Login/Login.react';
 import ForgotPassword from './components/Auth/ForgotPassword/ForgotPassword.react';
@@ -48,6 +49,7 @@ const App = () => (
           <Route exact path="/signup" component={SignUp} />
           <Route exact path="/logout" component={Logout} />
           <Route exact path="/settings" component={Settings} />
+          <Route exact path="/admin" component={Admin} />
           <Route exact path="/verify-account" component={VerifyAccount} />
           <Route exact path="/resetpass" component={ResetPassword} />
           <Route exact path="/delete-account" component={DeleteAccount} />


### PR DESCRIPTION
Fixes #291 

Changes: 
- Implement a basic Admin page which can only be accessible by users with admin user roles
- Add Admin tab in menu below settings

Surge Deployment Link: https://pr-292-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![a2](https://user-images.githubusercontent.com/30981465/42048682-958ace12-7b21-11e8-8447-7c4c4b12f8b5.png)
![a3](https://user-images.githubusercontent.com/30981465/42048694-9e25e87c-7b21-11e8-974e-c316d002ce4a.png)
![s4](https://user-images.githubusercontent.com/30981465/42048817-f4225ae4-7b21-11e8-8029-ff8d4ce9e85f.png)