### PR TITLE
Link settings in menu to settings and add delete account as an option

### DIFF
--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -1,7 +1,7 @@
 .navBar {
   background-color:#EEE;
-  width:327.5px;
-  height:450px;
+  width:327px;
+  height:500px;
   min-width:180px;
   float:left;
 }
@@ -17,6 +17,11 @@
 
 .setting-item{
   width:97%;
+}
+
+.Link a {
+  color : #1DA1F5;
+  text-decoration : none;
 }
 
 .settings-app {
@@ -46,7 +51,7 @@
   padding: 0px 0px;
   user-select: none;
   width: 100%;
-  height:450px;
+  height:500px;
 }
 
 
@@ -65,7 +70,7 @@
 .settings {
   padding:20px 20px 20px 30px;
   width:598.5px;
-  height:450px;
+  height:500px;
   float:right;
   background-color: #fff;
 }
@@ -115,6 +120,7 @@
     min-height:unset;
     height:65px;
   }
+
   .settings-list{
     display: none;
   }
@@ -123,13 +129,21 @@
     display: block;
   }
 
+  .settings {
+    height:500px;
+  }
+
+  .settings-app {
+    min-height:550px;
+  }
+
 }
 @media screen and (max-width: 395px) {
   .settings-app {
-    height:76vh;
+    height:500px;
   }
 
   .settings {
-    height:76vh;
+    height:500px;
   }
 }

--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -18,6 +18,7 @@ import MenuItem from 'material-ui/MenuItem';
 import Menu from 'material-ui/Menu';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
+import { Link } from 'react-router-dom';
 import ChangePassword from '../Auth/ChangePassword/ChangePassword.react';
 import * as Actions from '../../actions/API.actions';
 
@@ -874,6 +875,28 @@ class Settings extends Component {
                   />
                 )}
               </div>
+              {this.state.selectedSetting !== 'Account' ? (
+                ''
+              ) : (
+                <div>
+                  <hr
+                    className="Divider"
+                    style={{ height: '2px', marginTop: '25px' }}
+                  />
+                  <p
+                    style={{
+                      textAlign: 'center',
+                      marginTop: '20px',
+                      display: 'flex',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <span className="Link">
+                      <Link to="/delete-account">Deactivate your account</Link>
+                    </span>
+                  </p>
+                </div>
+              )}
             </div>
           </Paper>
         </div>

--- a/src/components/StaticAppBar/StaticAppBar.js
+++ b/src/components/StaticAppBar/StaticAppBar.js
@@ -86,13 +86,7 @@ const ListMenu = () => (
       {cookies.get('loggedIn') ? (
         <MenuItem
           primaryText="Settings"
-          menuItems={[
-            <MenuItem
-              key="1"
-              primaryText="Delete Account"
-              containerElement={<Link to="/delete-account" />}
-            />,
-          ]}
+          containerElement={<Link to="/settings" />}
           rightIcon={<Settings />}
         />
       ) : null}


### PR DESCRIPTION
Fixes #293 

Changes:
- Link settings in menu to '/settings'
- Add delete account as an option in menu instead of child of settings

Surge Deployment Link: https://pr-297-fossasia-susi-accounts.surge.sh

Screenshots for the change:
Before
![s1](https://user-images.githubusercontent.com/30981465/42049126-ab079abc-7b22-11e8-9a45-7ce108d76ad5.png)
Now
![d1](https://user-images.githubusercontent.com/30981465/42126688-37773304-7ca9-11e8-8a73-65be96a0c969.png)
