### PR TITLE
 Mobile field should accept only numerical inputs

### DIFF
--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -323,10 +323,13 @@ class Settings extends Component {
   };
 
   handlePhoneNo = event => {
-    this.setState({
-      PhoneNo: event.target.value,
-      settingsChanged: true,
-    });
+    const re = /^[0-9\b]+$/;
+    if (event.target.value === '' || re.test(event.target.value)) {
+      this.setState({
+        PhoneNo: event.target.value,
+        settingsChanged: true,
+      });
+    }
   };
 
   loadSettings = (e, value) => {


### PR DESCRIPTION
Fixes #314 

Changes:  Mobile field should accept only numerical inputs

Surge Deployment Link: https://pr-315-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![m1](https://user-images.githubusercontent.com/30981465/42505927-f586ae7c-845d-11e8-9299-5afb501e8ad1.png)