### PR TITLE
Fix pagination issue and add card style for tabs on admin page

### DIFF
--- a/src/components/Admin/Admin.css
+++ b/src/components/Admin/Admin.css
@@ -22,10 +22,10 @@
     background-color: #ffffff;
 }
 
-.h1{
+.h2{
     padding-top: 65px;
-    font-size: 40px;
     margin-left: 21px;
+    font-size: 35px;
 }
 
 .containerPaper{

--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -59,7 +59,7 @@ class Admin extends Component {
     const tabStyle = {
       width: '100%',
       animated: false,
-      textAlign: 'center',
+      textAlign: 'left',
       display: 'inline-block',
     };
 
@@ -69,11 +69,15 @@ class Admin extends Component {
           <div>
             <div className="heading">
               <StaticAppBar {...this.props} />
-              <h1 className="h1">SUSI.AI Admin Panel</h1>
+              <h2 className="h2">Admin Panel</h2>
             </div>
             <div className="tabs">
               <Paper style={tabStyle} zDepth={0}>
-                <Tabs tabPosition={this.state.tabPosition} animated={false}>
+                <Tabs
+                  tabPosition={this.state.tabPosition}
+                  animated={false}
+                  type="card"
+                >
                   <TabPane tab="Admin" key="1">
                     Tab for Admin Content
                   </TabPane>

--- a/src/components/Admin/ListUser/ListUser.css
+++ b/src/components/Admin/ListUser/ListUser.css
@@ -9,3 +9,47 @@
     margin-left: 30px;
     margin-right: 30px;
 }
+
+@font-face {
+  font-family: 'anticon';
+  src: url('https://at.alicdn.com/t/font_zck90zmlh7hf47vi.eot');
+  /* IE9*/
+  src: url('https://at.alicdn.com/t/font_zck90zmlh7hf47vi.eot?#iefix')
+       format('embedded-opentype'),
+ /* chrome、firefox */
+       url('https://at.alicdn.com/t/font_zck90zmlh7hf47vi.woff')
+       format('woff'),
+ /* chrome、firefox、opera、Safari, Android, iOS 4.2+*/
+       url('https://at.alicdn.com/t/font_zck90zmlh7hf47vi.ttf')
+       format('truetype'),
+ /* iOS 4.1- */
+       url('https://at.alicdn.com/t/font_zck90zmlh7hf47vi.svg#iconfont')
+       format('svg');
+}
+.anticon {
+  display: inline-block;
+  font-style: normal;
+  vertical-align: baseline;
+  text-align: center;
+  text-transform: none;
+  line-height: 1;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.anticon:before {
+  display: block;
+  font-family: "anticon";
+}
+.anticon-step-forward:before {
+  content: "\e600";
+}
+.anticon-step-backward:before {
+  content: "\e601";
+}
+.anticon-forward:before {
+  content: "\e602";
+}
+.anticon-backward:before {
+  content: "\e603";
+}

--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -8,6 +8,7 @@ import Dialog from 'material-ui/Dialog';
 import MenuItem from 'material-ui/MenuItem';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import 'antd/lib/table/style/index.css';
+import 'antd/lib/pagination/style/index.css';
 
 const cookies = new Cookies();
 

--- a/src/components/StaticAppBar/StaticAppBar.js
+++ b/src/components/StaticAppBar/StaticAppBar.js
@@ -93,6 +93,11 @@ const ListMenu = () => (
           rightIcon={<Settings />}
         />
       ) : null}
+      <MenuItem
+        primaryText="About"
+        href="http://chat.susi.ai/overview"
+        rightIcon={<Info />}
+      />
       {cookies.get('showAdmin') === true ? (
         <MenuItem
           primaryText="Admin"
@@ -100,11 +105,6 @@ const ListMenu = () => (
           containerElement={<Link to="/admin" />}
         />
       ) : null}
-      <MenuItem
-        primaryText="About"
-        href="http://chat.susi.ai/overview"
-        rightIcon={<Info />}
-      />
       {cookies.get('loggedIn') ? (
         <MenuItem
           primaryText="Logout"


### PR DESCRIPTION
Fixes #319 

Changes: 
- Pagination on admin tab is not working properly
- Remove SUSI.AI from heading of admin page and change to H2.
- Position of tabs should be left
- Implement card style for tabs similar to admin panel of open event
- Change position of Admin in menu below About

Surge Deployment Link(for Admins): https://pr-320-fossasia-susi-accounts.surge.sh

Test Link(for non Admins/No login required):http://womanly-car.surge.sh/

Screenshots for the change:
Implement tab style similar to open event admin panel and remove SUSI.Ai from heading
![a1](https://user-images.githubusercontent.com/30981465/42641867-30ae3a9a-8613-11e8-8fbe-ae675b639fae.png)
Before:
![a1](https://user-images.githubusercontent.com/30981465/42641156-84813868-8611-11e8-9c69-8f97b1977d87.png)

Fix issues with pagination
![p1](https://user-images.githubusercontent.com/30981465/42642083-a8ed08c4-8613-11e8-9b6a-f356a816f757.png)
Before:
![p1](https://user-images.githubusercontent.com/30981465/42641132-7b132e44-8611-11e8-96fe-9694012cf863.png)

