### PR TITLE
Show all skills on admin page

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import Paper from 'material-ui/Paper';
 import Tabs from 'antd/lib/tabs';
 import ListUser from './ListUser/ListUser';
+import ListSkills from './ListSkills/ListSkills';
 import 'antd/lib/tabs/style/index.css';
 import NotFound from './../NotFound/NotFound.react';
 
@@ -80,7 +81,10 @@ class Admin extends Component {
                   <TabPane tab="Users" key="2">
                     <ListUser />
                   </TabPane>
-                  <TabPane tab="Permissions" key="3">
+                  <TabPane tab="Skills" key="3">
+                    <ListSkills />
+                  </TabPane>
+                  <TabPane tab="Permissions" key="4">
                     Permission Content Tab
                   </TabPane>
                 </Tabs>

--- a/src/components/Admin/ListSkills/ListSkills.css
+++ b/src/components/Admin/ListSkills/ListSkills.css
@@ -1,0 +1,11 @@
+.banner{
+    background-color: #f7f7f7;
+}
+.h1{
+    padding-top: 4%;
+    font-size: 50px;
+}
+.table{
+    margin-left: 30px;
+    margin-right: 30px;
+}

--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import Table from 'antd/lib/table';
+import CircularProgress from 'material-ui/CircularProgress';
+import Snackbar from 'material-ui/Snackbar';
+import './ListSkills.css';
+import * as $ from 'jquery';
+
+const columns = [
+  {
+    title: 'Skill Name',
+    dataIndex: 'skillName',
+    width: '25%',
+  },
+  {
+    title: 'Type',
+    dataIndex: 'type',
+    width: '20%',
+  },
+  {
+    title: 'Author',
+    dataIndex: 'author',
+    width: '25%',
+  },
+  {
+    title: 'Status',
+    dataIndex: 'status',
+    width: '20%',
+  },
+  {
+    title: 'Action',
+    dataIndex: 'action',
+    width: '10%',
+    // eslint-disable-next-line
+    render: () => {
+      return (
+        <span>
+          <div style={{ cursor: 'pointer', color: '#49A9EE' }}>Edit</div>
+        </span>
+      );
+    },
+  },
+];
+
+class ListSkills extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      skillsData: [],
+      loading: true,
+      openSnackbar: false,
+      msgSnackbar: '',
+    };
+  }
+
+  componentDidMount() {
+    this.loadSkills();
+  }
+
+  loadSkills = () => {
+    let url =
+      'https://api.susi.ai/cms/getSkillList.json?applyFilter=true&filter_name=ascending&filter_type=lexicographical';
+    let self = this;
+    let skillsData = [];
+    $.ajax({
+      url: url,
+      jsonpCallback: 'pxcd',
+      dataType: 'jsonp',
+      jsonp: 'callback',
+      crossDomain: true,
+      success: function(data) {
+        for (let i of data.filteredData) {
+          skillsData.push({
+            skillName: i.skill_name,
+            type: 'public',
+            status: 'Not Reviewed',
+            ...i,
+          });
+        }
+        self.setState({
+          skillsData: skillsData,
+          loading: false,
+        });
+      },
+      error: function(err) {
+        self.setState({
+          loading: false,
+          openSnackbar: true,
+          msgSnackbar: "Error. Couldn't fetch skills.",
+        });
+      },
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        {this.state.loading ? (
+          <div className="center">
+            <CircularProgress size={62} color="#4285f5" />
+            <h4>Loading</h4>
+          </div>
+        ) : (
+          <div className="table">
+            <Table
+              columns={columns}
+              rowKey={record => record.registered}
+              dataSource={this.state.skillsData}
+              loading={this.state.loading}
+            />
+          </div>
+        )}
+        <Snackbar
+          open={this.state.openSnackbar}
+          message={this.state.msgSnackbar}
+          autoHideDuration={2000}
+          onRequestClose={() => {
+            this.setState({ openSnackbar: false });
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+export default ListSkills;


### PR DESCRIPTION
Fixes #321 

Changes: Showing all skills on `Skills` tab on admin page.

Surge Deployment Link: http://enormous-jar.surge.sh/. Choose `Admin` from burger menu.

Screenshots for the change:

<img width="1118" alt="screen shot 2018-07-13 at 6 20 22 pm" src="https://user-images.githubusercontent.com/31174685/42692502-91097aba-86c9-11e8-8bcd-bcb162824331.png">
