### PR TITLE
Allow admin to change review status of skills

### DIFF
--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -1,45 +1,16 @@
 import React from 'react';
 import Table from 'antd/lib/table';
+import FlatButton from 'material-ui/FlatButton';
+import Dialog from 'material-ui/Dialog';
+import DropDownMenu from 'material-ui/DropDownMenu';
+import MenuItem from 'material-ui/MenuItem';
 import CircularProgress from 'material-ui/CircularProgress';
 import Snackbar from 'material-ui/Snackbar';
+import Cookies from 'universal-cookie';
 import './ListSkills.css';
 import * as $ from 'jquery';
 
-const columns = [
-  {
-    title: 'Skill Name',
-    dataIndex: 'skillName',
-    width: '25%',
-  },
-  {
-    title: 'Type',
-    dataIndex: 'type',
-    width: '20%',
-  },
-  {
-    title: 'Author',
-    dataIndex: 'author',
-    width: '25%',
-  },
-  {
-    title: 'Status',
-    dataIndex: 'status',
-    width: '20%',
-  },
-  {
-    title: 'Action',
-    dataIndex: 'action',
-    width: '10%',
-    // eslint-disable-next-line
-    render: () => {
-      return (
-        <span>
-          <div style={{ cursor: 'pointer', color: '#49A9EE' }}>Edit</div>
-        </span>
-      );
-    },
-  },
-];
+const cookies = new Cookies();
 
 class ListSkills extends React.Component {
   constructor(props) {
@@ -49,18 +20,115 @@ class ListSkills extends React.Component {
       loading: true,
       openSnackbar: false,
       msgSnackbar: '',
+      isAction: false,
+      showDialog: false,
+      skillName: '',
+      skillModel: '',
+      skillGroup: '',
+      skillLanguage: '',
+      skillReviewStatus: false,
+      changeReviewStatusSuccessDialog: false,
+      changeReviewStatusFailureDialog: false,
     };
+    this.columns = [
+      {
+        title: 'Name',
+        dataIndex: 'skillName',
+        sorter: false,
+        width: '20%',
+      },
+      {
+        title: 'Group',
+        dataIndex: 'group',
+        width: '15%',
+      },
+      {
+        title: 'Language',
+        dataIndex: 'language',
+        width: '10%',
+      },
+      {
+        title: 'Type',
+        dataIndex: 'type',
+        width: '10%',
+      },
+      {
+        title: 'Author',
+        dataIndex: 'author',
+        width: '20%',
+      },
+      {
+        title: 'Status',
+        dataIndex: 'status',
+        width: '15%',
+      },
+      {
+        title: 'Action',
+        dataIndex: 'action',
+        width: '10%',
+        // eslint-disable-next-line
+        render: (text, record) => {
+          return (
+            <span>
+              <div
+                style={{ cursor: 'pointer', color: '#49A9EE' }}
+                onClick={() =>
+                  this.handleOpen(
+                    record.skillName,
+                    record.model,
+                    record.group,
+                    record.language,
+                    record.reviewStatus,
+                  )
+                }
+              >
+                Edit
+              </div>
+            </span>
+          );
+        },
+      },
+    ];
+    this.handleChange = this.handleChange.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+    this.handleOpen = this.handleOpen.bind(this);
+    this.handleStatusChange = this.handleStatusChange.bind(this);
+    this.handleFinish = this.handleFinish.bind(this);
   }
 
   componentDidMount() {
     this.loadSkills();
   }
 
+  changeStatus = () => {
+    let url;
+    url =
+      `https://api.susi.ai/cms/changeSkillStatus.json?model=${
+        this.state.skillModel
+      }&group=${this.state.skillGroup}&language=${
+        this.state.skillLanguage
+      }&skill=${this.state.skillName}&reviewed=${
+        this.state.skillReviewStatus
+      }&access_token=` + cookies.get('loggedIn');
+    $.ajax({
+      url: url,
+      dataType: 'jsonp',
+      jsonp: 'callback',
+      crossDomain: true,
+      success: function(data) {
+        this.setState({ changeReviewStatusSuccessDialog: true });
+      }.bind(this),
+      error: function(err) {
+        console.log(err);
+        this.setState({ changeReviewStatusFailureDialog: true });
+      }.bind(this),
+    });
+  };
+
   loadSkills = () => {
     let url =
       'https://api.susi.ai/cms/getSkillList.json?applyFilter=true&filter_name=ascending&filter_type=lexicographical';
     let self = this;
-    let skillsData = [];
     $.ajax({
       url: url,
       jsonpCallback: 'pxcd',
@@ -68,16 +136,22 @@ class ListSkills extends React.Component {
       jsonp: 'callback',
       crossDomain: true,
       success: function(data) {
+        let skills = [];
         for (let i of data.filteredData) {
-          skillsData.push({
+          let skill = {
             skillName: i.skill_name,
+            model: i.model,
+            group: i.group,
+            language: i.language,
+            reviewStatus: i.reviewed,
             type: 'public',
-            status: 'Not Reviewed',
-            ...i,
-          });
+            author: i.author,
+            status: i.reviewed ? 'Approved' : 'Not Reviewed',
+          };
+          skills.push(skill);
         }
         self.setState({
-          skillsData: skillsData,
+          skillsData: skills,
           loading: false,
         });
       },
@@ -91,7 +165,59 @@ class ListSkills extends React.Component {
     });
   };
 
+  handleChange = () => {
+    this.changeStatus();
+    this.setState({
+      showDialog: false,
+    });
+  };
+
+  handleOpen = (name, model, group, language, reviewStatus) => {
+    this.setState({
+      skillModel: model,
+      skillGroup: group,
+      skillLanguage: language,
+      skillName: name,
+      skillReviewStatus: reviewStatus,
+      showDialog: true,
+    });
+  };
+
+  handleClose = () => {
+    this.setState({
+      showDialog: false,
+    });
+  };
+
+  handleStatusChange = (event, index, value) => {
+    this.setState({
+      skillReviewStatus: value,
+    });
+  };
+
+  handleFinish = () => {
+    window.location.reload();
+  };
+
   render() {
+    const actions = [
+      <FlatButton
+        key={1}
+        label="Change"
+        primary={true}
+        onTouchTap={this.handleChange}
+      />,
+      <FlatButton
+        key={2}
+        label="Cancel"
+        primary={false}
+        onTouchTap={this.handleClose}
+      />,
+    ];
+
+    const blueThemeColor = { color: 'rgb(66, 133, 244)' };
+    const themeForegroundColor = '#272727';
+    const themeBackgroundColor = '#fff';
     return (
       <div>
         {this.state.loading ? (
@@ -101,8 +227,93 @@ class ListSkills extends React.Component {
           </div>
         ) : (
           <div className="table">
+            <Dialog
+              title="Skill Settings"
+              actions={actions}
+              model={true}
+              open={this.state.showDialog}
+            >
+              <div>
+                Change the review status of skill {this.state.skillName}
+              </div>
+              <div>
+                <DropDownMenu
+                  selectedMenuItemStyle={blueThemeColor}
+                  onChange={this.handleStatusChange}
+                  value={this.state.skillReviewStatus}
+                  labelStyle={{ color: themeForegroundColor }}
+                  menuStyle={{ backgroundColor: themeBackgroundColor }}
+                  menuItemStyle={{ color: themeForegroundColor }}
+                  style={{
+                    width: '250px',
+                    marginLeft: '-20px',
+                  }}
+                  autoWidth={false}
+                >
+                  <MenuItem
+                    primaryText="Approved"
+                    value={true}
+                    className="setting-item"
+                  />
+                  <MenuItem
+                    primaryText="Not Approved"
+                    value={false}
+                    className="setting-item"
+                  />
+                </DropDownMenu>
+              </div>
+            </Dialog>
+            <Dialog
+              title="Success"
+              actions={
+                <FlatButton
+                  key={1}
+                  label="Ok"
+                  primary={true}
+                  onTouchTap={this.handleFinish}
+                />
+              }
+              modal={true}
+              open={this.state.changeReviewStatusSuccessDialog}
+            >
+              <div>
+                Review status of
+                <span style={{ fontWeight: 'bold', margin: '0 5px' }}>
+                  {this.state.skillName}
+                </span>
+                is changed to
+                <span style={{ fontWeight: 'bold', margin: '0 5px' }}>
+                  {this.state.skillReviewStatus ? 'Approved' : 'Not Approved'}
+                </span>
+                successfully!
+              </div>
+            </Dialog>
+            <Dialog
+              title="Failed!"
+              actions={
+                <FlatButton
+                  key={1}
+                  label="Ok"
+                  primary={true}
+                  onTouchTap={this.handleFinish}
+                />
+              }
+              modal={true}
+              open={this.state.changeReviewStatusFailureDialog}
+            >
+              <div>
+                Error! Review status of
+                <span style={{ fontWeight: 'bold', margin: '0 5px' }}>
+                  {this.state.skillName}
+                </span>
+                could not be changed to
+                <span style={{ fontWeight: 'bold', margin: '0 5px' }}>
+                  {this.state.skillReviewStatus ? 'Approved' : 'Not Approved'}
+                </span>!
+              </div>
+            </Dialog>
             <Table
-              columns={columns}
+              columns={this.columns}
               rowKey={record => record.registered}
               dataSource={this.state.skillsData}
               loading={this.state.loading}


### PR DESCRIPTION
Fixes #328 

Changes: Allowing admin to change review status of skills.

Test Link: http://sweet-soap.surge.sh/. Choose `Admin` from the dropdown hamburger menu to access admin tab. (Logging in is not required)

Screenshots for the change:

<img width="1116" alt="screen shot 2018-07-15 at 5 22 26 pm" src="https://user-images.githubusercontent.com/31174685/42733703-e189f358-8853-11e8-8436-5db6d2860184.png">

<img width="808" alt="screen shot 2018-07-13 at 2 18 07 am" src="https://user-images.githubusercontent.com/31174685/42658478-17310ae0-8643-11e8-95a7-42d9621944d1.png">

<img width="802" alt="screen shot 2018-07-13 at 2 18 17 am" src="https://user-images.githubusercontent.com/31174685/42658484-1a28d66a-8643-11e8-9370-220a2924e4c6.png">

<img width="790" alt="screen shot 2018-07-13 at 2 22 28 am" src="https://user-images.githubusercontent.com/31174685/42658672-a044dd52-8643-11e8-9f3e-08e82422301d.png">
The review status will change if you're the admin.


<img width="790" alt="screen shot 2018-07-13 at 2 18 27 am" src="https://user-images.githubusercontent.com/31174685/42658489-1b6c35b2-8643-11e8-8c5b-d935fcf94d57.png">
It'll fail if you try to change review status but you're not admin.