### PR TITLE
Fixes #349: Display a loader while determining admin role instead of 404

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import './Admin.css';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.js';
 import $ from 'jquery';
+import CircularProgress from 'material-ui/CircularProgress';
 import Cookies from 'universal-cookie';
 import PropTypes from 'prop-types';
 import Paper from 'material-ui/Paper';
@@ -20,7 +21,7 @@ class Admin extends Component {
     super(props);
 
     this.state = {
-      tabPosition: 'top',
+      loading: true,
       isAdmin: false,
     };
   }
@@ -39,11 +40,13 @@ class Admin extends Component {
       success: function(response) {
         // console.log(response.showAdmin);
         this.setState({
+          loading: false,
           isAdmin: response.showAdmin,
         });
       }.bind(this),
       error: function(errorThrown) {
         this.setState({
+          loading: false,
           isAdmin: false,
         });
         console.log(errorThrown);
@@ -57,47 +60,57 @@ class Admin extends Component {
   };
 
   render() {
-    const tabStyle = {
-      width: '100%',
-      animated: false,
-      textAlign: 'left',
-      display: 'inline-block',
+    const styles = {
+      tabStyle: {
+        width: '100%',
+        animated: false,
+        display: 'inline-block',
+        marginTop: '20px',
+      },
+      centerLoader: {
+        marginTop: '100px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+      },
     };
-
     return (
       <div>
-        {this.state.isAdmin ? (
-          <div>
-            <div className="heading">
-              <StaticAppBar {...this.props} />
-              <h2 className="h2">Admin Panel</h2>
-            </div>
-            <div className="tabs">
-              <Paper style={tabStyle} zDepth={0}>
-                <Tabs
-                  tabPosition={this.state.tabPosition}
-                  animated={false}
-                  type="card"
-                  style={{ minHeight: '500px' }}
-                >
-                  <TabPane tab="Admin" key="1">
-                    Tab for Admin Content
-                  </TabPane>
-                  <TabPane tab="Users" key="2">
-                    <ListUser />
-                  </TabPane>
-                  <TabPane tab="Skills" key="3">
-                    <ListSkills />
-                  </TabPane>
-                  <TabPane tab="Permissions" key="4">
-                    Permission Content Tab
-                  </TabPane>
-                </Tabs>
-              </Paper>
-            </div>
+        <StaticAppBar {...this.props} />
+        {this.state.loading ? (
+          <div style={styles.centerLoader}>
+            <CircularProgress size={62} color="#4285f5" />
+            <h4>Loading</h4>
           </div>
         ) : (
-          <NotFound />
+          <div>
+            {this.state.isAdmin ? (
+              <div>
+                <h2 className="h2">Admin Panel</h2>
+                <div className="tabs">
+                  <Paper style={styles.tabStyle} zDepth={0}>
+                    <Tabs tabPosition="top" animated={false} type="card">
+                      <TabPane tab="Admin" key="1">
+                        Tab for Admin Content
+                      </TabPane>
+                      <TabPane tab="Users" key="2">
+                        <ListUser />
+                      </TabPane>
+                      <TabPane tab="Skills" key="3">
+                        <ListSkills />
+                      </TabPane>
+                      <TabPane tab="Permissions" key="4">
+                        Permission Content Tab
+                      </TabPane>
+                    </Tabs>
+                  </Paper>
+                </div>
+              </div>
+            ) : (
+              <NotFound />
+            )}
+          </div>
         )}
       </div>
     );


### PR DESCRIPTION
Fixes #349 

Changes: Add loader while admin section is loading instead of 404

Surge Deployment Link: https://pr-352-fossasia-susi-accounts.surge.sh

Screenshots for the change:
Just visit /admin