### PR TITLE
Implement subroutes for admin tabs and minor fixes

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -1,17 +1,12 @@
 import React, { Component } from 'react';
 import './Admin.css';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.js';
-import $ from 'jquery';
 import Cookies from 'universal-cookie';
 import PropTypes from 'prop-types';
 import Paper from 'material-ui/Paper';
 import Tabs from 'antd/lib/tabs';
-import ListUser from './ListUser/ListUser';
-import ListSkills from './ListSkills/ListSkills';
 import 'antd/lib/tabs/style/index.css';
 import NotFound from './../NotFound/NotFound.react';
-
-import urls from '../../utils/urls';
 
 const cookies = new Cookies();
 
@@ -23,39 +18,21 @@ class Admin extends Component {
 
     this.state = {
       tabPosition: 'top',
-      isAdmin: false,
     };
-  }
-
-  componentDidMount() {
-    let url;
-    url =
-      `${urls.API_URL}/aaa/showAdminService.json?access_token=` +
-      cookies.get('loggedIn');
-    $.ajax({
-      url: url,
-      dataType: 'jsonp',
-      jsonpCallback: 'pyfw',
-      jsonp: 'callback',
-      crossDomain: true,
-      success: function(response) {
-        // console.log(response.showAdmin);
-        this.setState({
-          isAdmin: response.showAdmin,
-        });
-      }.bind(this),
-      error: function(errorThrown) {
-        this.setState({
-          isAdmin: false,
-        });
-        console.log(errorThrown);
-      }.bind(this),
-    });
   }
 
   handleClose = () => {
     this.props.history.push('/');
     window.location.reload();
+  };
+
+  handleTabChange = activeKey => {
+    if (activeKey === '2') {
+      this.props.history.push('/admin/users');
+    }
+    if (activeKey === '3') {
+      this.props.history.push('/admin/skills');
+    }
   };
 
   render() {
@@ -68,7 +45,7 @@ class Admin extends Component {
 
     return (
       <div>
-        {this.state.isAdmin ? (
+        {cookies.get('showAdmin') === 'true' ? (
           <div>
             <div className="heading">
               <StaticAppBar {...this.props} />
@@ -77,6 +54,7 @@ class Admin extends Component {
             <div className="tabs">
               <Paper style={tabStyle} zDepth={0}>
                 <Tabs
+                  onTabClick={this.handleTabChange}
                   tabPosition={this.state.tabPosition}
                   animated={false}
                   type="card"
@@ -85,15 +63,8 @@ class Admin extends Component {
                   <TabPane tab="Admin" key="1">
                     Tab for Admin Content
                   </TabPane>
-                  <TabPane tab="Users" key="2">
-                    <ListUser />
-                  </TabPane>
-                  <TabPane tab="Skills" key="3">
-                    <ListSkills />
-                  </TabPane>
-                  <TabPane tab="Permissions" key="4">
-                    Permission Content Tab
-                  </TabPane>
+                  <TabPane tab="Users" key="2" />
+                  <TabPane tab="Skills" key="3" />
                 </Tabs>
               </Paper>
             </div>

--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Table from 'antd/lib/table';
 import { LocaleProvider } from 'antd';
 import enUS from 'antd/lib/locale-provider/en_US';
@@ -8,6 +9,10 @@ import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
 import CircularProgress from 'material-ui/CircularProgress';
 import Snackbar from 'material-ui/Snackbar';
+import Paper from 'material-ui/Paper';
+import Tabs from 'antd/lib/tabs';
+import NotFound from '../../NotFound/NotFound.react';
+import StaticAppBar from '../../StaticAppBar/StaticAppBar.js';
 import Cookies from 'universal-cookie';
 import './ListSkills.css';
 import * as $ from 'jquery';
@@ -15,6 +20,8 @@ import * as $ from 'jquery';
 import urls from '../../../utils/urls';
 
 const cookies = new Cookies();
+
+const TabPane = Tabs.TabPane;
 
 class ListSkills extends React.Component {
   constructor(props) {
@@ -336,6 +343,15 @@ class ListSkills extends React.Component {
     });
   };
 
+  handleTabChange = activeKey => {
+    if (activeKey === '1') {
+      this.props.history.push('/admin');
+    }
+    if (activeKey === '2') {
+      this.props.history.push('/admin/users');
+    }
+  };
+
   handleReviewStatusChange = (event, index, value) => {
     this.setState({
       skillReviewStatus: value,
@@ -372,143 +388,195 @@ class ListSkills extends React.Component {
     const themeForegroundColor = '#272727';
     const themeBackgroundColor = '#fff';
 
+    const tabStyle = {
+      width: '100%',
+      animated: false,
+      textAlign: 'left',
+      display: 'inline-block',
+    };
+
     return (
       <div>
-        {this.state.loading ? (
-          <div className="center">
-            <CircularProgress size={62} color="#4285f5" />
-            <h4>Loading</h4>
+        {cookies.get('showAdmin') === 'true' ? (
+          <div>
+            <div className="heading">
+              <StaticAppBar {...this.props} />
+              <h2 className="h2">Skills Panel</h2>
+            </div>
+            <div className="tabs">
+              <Paper style={tabStyle} zDepth={0}>
+                <Tabs
+                  defaultActiveKey="3"
+                  onTabClick={this.handleTabChange}
+                  tabPosition={this.state.tabPosition}
+                  animated={false}
+                  type="card"
+                  style={{ minHeight: '500px' }}
+                >
+                  <TabPane tab="Admin" key="1">
+                    Tab for Admin Content
+                  </TabPane>
+                  <TabPane tab="Users" key="2" />
+                  <TabPane tab="Skills" key="3">
+                    <div>
+                      {this.state.loading ? (
+                        <div className="center">
+                          <CircularProgress size={62} color="#4285f5" />
+                          <h4>Loading</h4>
+                        </div>
+                      ) : (
+                        <div className="table">
+                          <Dialog
+                            title="Skill Settings"
+                            actions={actions}
+                            model={true}
+                            open={this.state.showDialog}
+                          >
+                            <div>
+                              Change the review status of skill{' '}
+                              {this.state.skillName}
+                            </div>
+                            <div>
+                              <DropDownMenu
+                                selectedMenuItemStyle={blueThemeColor}
+                                onChange={this.handleReviewStatusChange}
+                                value={this.state.skillReviewStatus}
+                                labelStyle={{ color: themeForegroundColor }}
+                                menuStyle={{
+                                  backgroundColor: themeBackgroundColor,
+                                }}
+                                menuItemStyle={{ color: themeForegroundColor }}
+                                style={{
+                                  width: '250px',
+                                  marginLeft: '-20px',
+                                }}
+                                autoWidth={false}
+                              >
+                                <MenuItem
+                                  primaryText="Approved"
+                                  value={true}
+                                  className="setting-item"
+                                />
+                                <MenuItem
+                                  primaryText="Not Approved"
+                                  value={false}
+                                  className="setting-item"
+                                />
+                              </DropDownMenu>
+                            </div>
+                            <div style={{ marginTop: '12px' }}>
+                              Change the edit status of skill{' '}
+                              {this.state.skillName}
+                            </div>
+                            <div>
+                              <DropDownMenu
+                                selectedMenuItemStyle={blueThemeColor}
+                                onChange={this.handleEditStatusChange}
+                                value={this.state.skillEditStatus}
+                                labelStyle={{ color: themeForegroundColor }}
+                                menuStyle={{
+                                  backgroundColor: themeBackgroundColor,
+                                }}
+                                menuItemStyle={{ color: themeForegroundColor }}
+                                style={{
+                                  width: '250px',
+                                  marginLeft: '-20px',
+                                }}
+                                autoWidth={false}
+                              >
+                                <MenuItem
+                                  primaryText="Editable"
+                                  value={true}
+                                  className="setting-item"
+                                />
+                                <MenuItem
+                                  primaryText="Not Editable"
+                                  value={false}
+                                  className="setting-item"
+                                />
+                              </DropDownMenu>
+                            </div>
+                          </Dialog>
+                          <Dialog
+                            title="Success"
+                            actions={
+                              <FlatButton
+                                key={1}
+                                label="Ok"
+                                primary={true}
+                                onTouchTap={this.handleFinish}
+                              />
+                            }
+                            modal={true}
+                            open={this.state.changeStatusSuccessDialog}
+                          >
+                            <div>
+                              Status of
+                              <span
+                                style={{ fontWeight: 'bold', margin: '0 5px' }}
+                              >
+                                {this.state.skillName}
+                              </span>
+                              has been changed successfully!
+                            </div>
+                          </Dialog>
+                          <Dialog
+                            title="Failed!"
+                            actions={
+                              <FlatButton
+                                key={1}
+                                label="Ok"
+                                primary={true}
+                                onTouchTap={this.handleFinish}
+                              />
+                            }
+                            modal={true}
+                            open={this.state.changeStatusFailureDialog}
+                          >
+                            <div>
+                              Error! Status of
+                              <span
+                                style={{ fontWeight: 'bold', margin: '0 5px' }}
+                              >
+                                {this.state.skillName}
+                              </span>
+                              could not be changed!
+                            </div>
+                          </Dialog>
+                          <LocaleProvider locale={enUS}>
+                            <Table
+                              columns={this.columns}
+                              rowKey={record => record.registered}
+                              dataSource={this.state.skillsData}
+                              loading={this.state.loading}
+                            />
+                          </LocaleProvider>
+                        </div>
+                      )}
+                      <Snackbar
+                        open={this.state.openSnackbar}
+                        message={this.state.msgSnackbar}
+                        autoHideDuration={2000}
+                        onRequestClose={() => {
+                          this.setState({ openSnackbar: false });
+                        }}
+                      />
+                    </div>
+                  </TabPane>
+                </Tabs>
+              </Paper>
+            </div>
           </div>
         ) : (
-          <div className="table">
-            <Dialog
-              title="Skill Settings"
-              actions={actions}
-              model={true}
-              open={this.state.showDialog}
-            >
-              <div>
-                Change the review status of skill {this.state.skillName}
-              </div>
-              <div>
-                <DropDownMenu
-                  selectedMenuItemStyle={blueThemeColor}
-                  onChange={this.handleReviewStatusChange}
-                  value={this.state.skillReviewStatus}
-                  labelStyle={{ color: themeForegroundColor }}
-                  menuStyle={{ backgroundColor: themeBackgroundColor }}
-                  menuItemStyle={{ color: themeForegroundColor }}
-                  style={{
-                    width: '250px',
-                    marginLeft: '-20px',
-                  }}
-                  autoWidth={false}
-                >
-                  <MenuItem
-                    primaryText="Approved"
-                    value={true}
-                    className="setting-item"
-                  />
-                  <MenuItem
-                    primaryText="Not Approved"
-                    value={false}
-                    className="setting-item"
-                  />
-                </DropDownMenu>
-              </div>
-              <div style={{ marginTop: '12px' }}>
-                Change the edit status of skill {this.state.skillName}
-              </div>
-              <div>
-                <DropDownMenu
-                  selectedMenuItemStyle={blueThemeColor}
-                  onChange={this.handleEditStatusChange}
-                  value={this.state.skillEditStatus}
-                  labelStyle={{ color: themeForegroundColor }}
-                  menuStyle={{ backgroundColor: themeBackgroundColor }}
-                  menuItemStyle={{ color: themeForegroundColor }}
-                  style={{
-                    width: '250px',
-                    marginLeft: '-20px',
-                  }}
-                  autoWidth={false}
-                >
-                  <MenuItem
-                    primaryText="Editable"
-                    value={true}
-                    className="setting-item"
-                  />
-                  <MenuItem
-                    primaryText="Not Editable"
-                    value={false}
-                    className="setting-item"
-                  />
-                </DropDownMenu>
-              </div>
-            </Dialog>
-            <Dialog
-              title="Success"
-              actions={
-                <FlatButton
-                  key={1}
-                  label="Ok"
-                  primary={true}
-                  onTouchTap={this.handleFinish}
-                />
-              }
-              modal={true}
-              open={this.state.changeStatusSuccessDialog}
-            >
-              <div>
-                Status of
-                <span style={{ fontWeight: 'bold', margin: '0 5px' }}>
-                  {this.state.skillName}
-                </span>
-                has been changed successfully!
-              </div>
-            </Dialog>
-            <Dialog
-              title="Failed!"
-              actions={
-                <FlatButton
-                  key={1}
-                  label="Ok"
-                  primary={true}
-                  onTouchTap={this.handleFinish}
-                />
-              }
-              modal={true}
-              open={this.state.changeStatusFailureDialog}
-            >
-              <div>
-                Error! Status of
-                <span style={{ fontWeight: 'bold', margin: '0 5px' }}>
-                  {this.state.skillName}
-                </span>
-                could not be changed!
-              </div>
-            </Dialog>
-            <LocaleProvider locale={enUS}>
-              <Table
-                columns={this.columns}
-                rowKey={record => record.registered}
-                dataSource={this.state.skillsData}
-                loading={this.state.loading}
-              />
-            </LocaleProvider>
-          </div>
+          <NotFound />
         )}
-        <Snackbar
-          open={this.state.openSnackbar}
-          message={this.state.msgSnackbar}
-          autoHideDuration={2000}
-          onRequestClose={() => {
-            this.setState({ openSnackbar: false });
-          }}
-        />
       </div>
     );
   }
 }
+
+ListSkills.propTypes = {
+  history: PropTypes.object,
+};
 
 export default ListSkills;

--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -1,18 +1,25 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import './ListUser.css';
 import $ from 'jquery';
 import Cookies from 'universal-cookie';
 import Table from 'antd/lib/table';
+import StaticAppBar from '../../StaticAppBar/StaticAppBar.js';
 import FlatButton from 'material-ui/FlatButton';
 import Dialog from 'material-ui/Dialog';
 import MenuItem from 'material-ui/MenuItem';
 import DropDownMenu from 'material-ui/DropDownMenu';
+import Paper from 'material-ui/Paper';
+import Tabs from 'antd/lib/tabs';
+import NotFound from '../../NotFound/NotFound.react';
 import { LocaleProvider } from 'antd';
 import enUS from 'antd/lib/locale-provider/en_US';
 
 import urls from '../../../utils/urls';
 
 const cookies = new Cookies();
+
+const TabPane = Tabs.TabPane;
 
 export default class ListUser extends Component {
   constructor(props) {
@@ -253,6 +260,15 @@ export default class ListUser extends Component {
     });
   };
 
+  handleTabChange = activeKey => {
+    if (activeKey === '1') {
+      this.props.history.push('/admin');
+    }
+    if (activeKey === '3') {
+      this.props.history.push('/admin/skills');
+    }
+  };
+
   handleUserRoleChange = (event, index, value) => {
     this.setState({
       userRole: value,
@@ -336,101 +352,154 @@ export default class ListUser extends Component {
     const themeForegroundColor = '#272727';
     const themeBackgroundColor = '#fff';
 
-    return (
-      <div className="table">
-        <div>
-          <Dialog
-            title="Change User Role"
-            actions={actions}
-            modal={true}
-            open={this.state.showEditDialog}
-          >
-            <div>
-              Select new User Role for
-              <span style={{ fontWeight: 'bold', marginLeft: '5px' }}>
-                {this.state.userEmail}
-              </span>
-            </div>
-            <div>
-              <DropDownMenu
-                selectedMenuItemStyle={blueThemeColor}
-                onChange={this.handleUserRoleChange}
-                value={this.state.userRole}
-                labelStyle={{ color: themeForegroundColor }}
-                menuStyle={{ backgroundColor: themeBackgroundColor }}
-                menuItemStyle={{ color: themeForegroundColor }}
-                style={{
-                  width: '250px',
-                  marginLeft: '-20px',
-                }}
-                autoWidth={false}
-              >
-                <MenuItem
-                  primaryText="USER"
-                  value="user"
-                  className="setting-item"
-                />
-                <MenuItem
-                  primaryText="REVIEWER"
-                  value="reviewer"
-                  className="setting-item"
-                />
-                <MenuItem
-                  primaryText="OPERATOR"
-                  value="operator"
-                  className="setting-item"
-                />
-                <MenuItem
-                  primaryText="ADMIN"
-                  value="admin"
-                  className="setting-item"
-                />
-                <MenuItem
-                  primaryText="SUPERADMIN"
-                  value="superadmin"
-                  className="setting-item"
-                />
-              </DropDownMenu>
-            </div>
-          </Dialog>
-          <Dialog
-            title="Success"
-            actions={
-              <FlatButton
-                key={1}
-                label="Ok"
-                primary={true}
-                onTouchTap={this.handleSuccess}
-              />
-            }
-            modal={true}
-            open={this.state.changeRoleDialog}
-          >
-            <div>
-              User role of
-              <span style={{ fontWeight: 'bold', margin: '0 5px' }}>
-                {this.state.userEmail}
-              </span>
-              is changed to
-              <span style={{ fontWeight: 'bold', margin: '0 5px' }}>
-                {this.state.userRole}
-              </span>
-              successfully!
-            </div>
-          </Dialog>
-        </div>
+    const tabStyle = {
+      width: '100%',
+      animated: false,
+      textAlign: 'left',
+      display: 'inline-block',
+    };
 
-        <LocaleProvider locale={enUS}>
-          <Table
-            columns={this.columns}
-            rowKey={record => record.registered}
-            dataSource={this.state.data}
-            pagination={this.state.pagination}
-            loading={this.state.loading}
-            onChange={this.handleTableChange}
-          />
-        </LocaleProvider>
+    return (
+      <div>
+        {cookies.get('showAdmin') === 'true' ? (
+          <div>
+            <div className="heading">
+              <StaticAppBar {...this.props} />
+              <h2 className="h2">Users Panel</h2>
+            </div>
+            <div className="tabs">
+              <Paper style={tabStyle} zDepth={0}>
+                <Tabs
+                  defaultActiveKey="2"
+                  onTabClick={this.handleTabChange}
+                  tabPosition={this.state.tabPosition}
+                  animated={false}
+                  type="card"
+                  style={{ minHeight: '500px' }}
+                >
+                  <TabPane tab="Admin" key="1" />
+                  <TabPane tab="Users" key="2">
+                    <div className="table">
+                      <div>
+                        <Dialog
+                          title="Change User Role"
+                          actions={actions}
+                          modal={true}
+                          open={this.state.showEditDialog}
+                        >
+                          <div>
+                            Select new User Role for
+                            <span
+                              style={{ fontWeight: 'bold', marginLeft: '5px' }}
+                            >
+                              {this.state.userEmail}
+                            </span>
+                          </div>
+                          <div>
+                            <DropDownMenu
+                              selectedMenuItemStyle={blueThemeColor}
+                              onChange={this.handleUserRoleChange}
+                              value={this.state.userRole}
+                              labelStyle={{ color: themeForegroundColor }}
+                              menuStyle={{
+                                backgroundColor: themeBackgroundColor,
+                              }}
+                              menuItemStyle={{ color: themeForegroundColor }}
+                              style={{
+                                width: '250px',
+                                marginLeft: '-20px',
+                              }}
+                              autoWidth={false}
+                            >
+                              <MenuItem
+                                primaryText="BOT"
+                                value="bot"
+                                className="setting-item"
+                              />
+                              <MenuItem
+                                primaryText="USER"
+                                value="user"
+                                className="setting-item"
+                              />
+                              <MenuItem
+                                primaryText="REVIEWER"
+                                value="reviewer"
+                                className="setting-item"
+                              />
+                              <MenuItem
+                                primaryText="OPERATOR"
+                                value="operator"
+                                className="setting-item"
+                              />
+                              <MenuItem
+                                primaryText="ADMIN"
+                                value="admin"
+                                className="setting-item"
+                              />
+                              <MenuItem
+                                primaryText="SUPERADMIN"
+                                value="superadmin"
+                                className="setting-item"
+                              />
+                            </DropDownMenu>
+                          </div>
+                        </Dialog>
+                        <Dialog
+                          title="Success"
+                          actions={
+                            <FlatButton
+                              key={1}
+                              label="Ok"
+                              primary={true}
+                              onTouchTap={this.handleSuccess}
+                            />
+                          }
+                          modal={true}
+                          open={this.state.changeRoleDialog}
+                        >
+                          <div>
+                            User role of
+                            <span
+                              style={{ fontWeight: 'bold', margin: '0 5px' }}
+                            >
+                              {this.state.userEmail}
+                            </span>
+                            is changed to
+                            <span
+                              style={{ fontWeight: 'bold', margin: '0 5px' }}
+                            >
+                              {this.state.userRole}
+                            </span>
+                            successfully!
+                          </div>
+                        </Dialog>
+                      </div>
+
+                      <LocaleProvider locale={enUS}>
+                        <Table
+                          columns={this.columns}
+                          rowKey={record => record.registered}
+                          dataSource={this.state.data}
+                          pagination={this.state.pagination}
+                          loading={this.state.loading}
+                          onChange={this.handleTableChange}
+                        />
+                      </LocaleProvider>
+                    </div>
+                  </TabPane>
+                  <TabPane tab="Skills" key="3" />
+                </Tabs>
+              </Paper>
+            </div>
+          </div>
+        ) : (
+          <NotFound />
+        )}
       </div>
     );
   }
 }
+
+ListUser.propTypes = {
+  history: PropTypes.object,
+};

--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -194,6 +194,34 @@ class Login extends Component {
         maxAge: time,
         domain: cookieDomain,
       });
+
+      let BASE_URL = `${urls.API_URL}`;
+
+      let url;
+      url = BASE_URL + '/aaa/showAdminService.json?access_token=' + loggedIn;
+      $.ajax({
+        url: url,
+        dataType: 'jsonp',
+        jsonpCallback: 'pyfw',
+        jsonp: 'callback',
+        crossDomain: true,
+        success: function(response) {
+          cookies.set('showAdmin', response.showAdmin, {
+            path: '/',
+            maxAge: time,
+            domain: cookieDomain,
+          });
+        }.bind(this),
+        error: function(errorThrown) {
+          cookies.set('showAdmin', 'false', {
+            path: '/',
+            maxAge: time,
+            domain: cookieDomain,
+          });
+          console.log(errorThrown);
+        }.bind(this),
+      });
+
       this.props.history.push('/settings', { showLogin: false });
     } else {
       this.setState({

--- a/src/components/StaticAppBar/StaticAppBar.js
+++ b/src/components/StaticAppBar/StaticAppBar.js
@@ -32,13 +32,6 @@ const cookieDomain = isProduction() ? '.susi.ai' : '';
 const cookies = new Cookies();
 
 class StaticAppBar extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showAdmin: false,
-    };
-  }
-
   handleScroll = event => {
     let scrollTop = event.pageY || event.target.body.scrollTop,
       itemTranslate = scrollTop > 60;
@@ -48,31 +41,6 @@ class StaticAppBar extends Component {
   };
 
   componentDidMount() {
-    $.ajax({
-      url:
-        `${urls.API_URL}` +
-        '/aaa/showAdminService.json?access_token=' +
-        cookies.get('loggedIn'),
-      dataType: 'jsonp',
-      jsonpCallback: 'pfns',
-      jsonp: 'callback',
-      crossDomain: true,
-      success: function(newResponse) {
-        let showAdmin = newResponse.showAdmin;
-        cookies.set('showAdmin', showAdmin, {
-          path: '/',
-          domain: cookieDomain,
-        });
-        this.setState({
-          showAdmin,
-        });
-        console.log(newResponse.showAdmin);
-      }.bind(this),
-      error: function(newErrorThrown) {
-        console.log(newErrorThrown);
-      },
-    });
-
     $.ajax({
       url:
         `${urls.API_URL}` +
@@ -207,7 +175,7 @@ class StaticAppBar extends Component {
             href={`${urls.CHAT_URL}/overview`}
             rightIcon={<Info />}
           />
-          {this.state.showAdmin === true ? (
+          {cookies.get('showAdmin') === 'true' ? (
             <MenuItem
               primaryText="Admin"
               rightIcon={<List />}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import ResetPassword from './components/Auth/ResetPassword/ResetPassword.react';
 import DeleteAccount from './components/Auth/DeleteAccount/DeleteAccount.react';
 import Settings from './components/Settings/Settings.react';
 import Admin from './components/Admin/Admin.js';
+import Users from './components/Admin/ListUser/ListUser.js';
+import Skills from './components/Admin/ListSkills/ListSkills.js';
 import VerifyAccount from './components/Auth/VerifyAccount/VerifyAccount.react';
 import Login from './components/Auth/Login/Login.react';
 import ForgotPassword from './components/Auth/ForgotPassword/ForgotPassword.react';
@@ -45,6 +47,8 @@ const App = () => (
           <Route exact path="/logout" component={Logout} />
           <Route exact path="/settings" component={Settings} />
           <Route exact path="/admin" component={Admin} />
+          <Route exact path="/admin/users" component={Users} />
+          <Route exact path="/admin/skills" component={Skills} />
           <Route exact path="/verify-account" component={VerifyAccount} />
           <Route exact path="/resetpass" component={ResetPassword} />
           <Route exact path="/delete-account" component={DeleteAccount} />


### PR DESCRIPTION
Fixes #345 
Fixes #352 

Changes: 
- Add subroutes for different admin tabs
- Implement `showAdmin` cookie during login to check admin status instead of calling API everytime on different components
- This reduces extra API calls and admin panel is loading instantly without 404 in between 
- Temporarily remove permissions tab as it is empty and will re implement it as a subroute like users tab in #334 

Surge Deployment Link: https://pr-353-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![a1](https://user-images.githubusercontent.com/30981465/42993372-d7d4e164-8c28-11e8-9752-f21fffb3a373.png)
![a2](https://user-images.githubusercontent.com/30981465/42993380-d959e48a-8c28-11e8-8070-19ea9568e2a8.png)
![a3](https://user-images.githubusercontent.com/30981465/42993843-13284994-8c2a-11e8-8789-e4effc7500ce.png)