### PR TITLE
Fixes #363: Persist showAdmin cookie over SUSI.AI subdomains

### DIFF
--- a/src/components/Auth/Logout.react.js
+++ b/src/components/Auth/Logout.react.js
@@ -27,7 +27,7 @@ class Logout extends Component {
     deleteCookie('loggedIn', { domain: cookieDomain, path: '/' });
     deleteCookie('serverUrl', { domain: cookieDomain, path: '/' });
     deleteCookie('emailId', { domain: cookieDomain, path: '/' });
-    deleteCookie('showAdmin', { path: '/' });
+    deleteCookie('showAdmin', { domain: cookieDomain, path: '/' });
     deleteCookie('username', { domain: cookieDomain, path: '/' });
     this.props.history.push('/');
     window.location.reload();

--- a/src/components/StaticAppBar/StaticAppBar.js
+++ b/src/components/StaticAppBar/StaticAppBar.js
@@ -59,6 +59,7 @@ class StaticAppBar extends Component {
         let showAdmin = newResponse.showAdmin;
         cookies.set('showAdmin', showAdmin, {
           path: '/',
+          domain: cookieDomain,
         });
         this.setState({
           showAdmin,


### PR DESCRIPTION
Fixes #363 

Changes: [Add here what changes were made in this issue and if possible provide links.]

Persist showAdmin cookie over SUSI.AI subdomains
Surge Deployment Link: Won't reflect the change as the PR is domain specific

Screenshots for the change:
NA