### PR TITLE
Removed user role BOT from dropdown in Admin Panel

### DIFF
--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -75,10 +75,6 @@ export default class ListUser extends Component {
         dataIndex: 'userRole',
         filters: [
           {
-            text: 'Bot',
-            value: 'bot',
-          },
-          {
             text: 'Anonymous',
             value: 'anonymous',
           },
@@ -369,11 +365,6 @@ export default class ListUser extends Component {
                 }}
                 autoWidth={false}
               >
-                <MenuItem
-                  primaryText="BOT"
-                  value="bot"
-                  className="setting-item"
-                />
                 <MenuItem
                   primaryText="USER"
                   value="user"


### PR DESCRIPTION
Fixes #361 

Changes: Removed user role `BOT` from dropdown in Admin Panel. 
Relevant PR on server: https://github.com/fossasia/susi_server/pull/1047

Surge Deployment Link: https://pr-365-fossasia-susi-accounts.surge.sh
