### PR TITLE
Fixes #350: Center the circular loader on skills tab

### DIFF
--- a/src/components/Admin/ListSkills/ListSkills.css
+++ b/src/components/Admin/ListSkills/ListSkills.css
@@ -1,11 +1,19 @@
-.banner{
+.banner {
     background-color: #f7f7f7;
 }
-.h1{
+
+.h1 {
     padding-top: 4%;
     font-size: 50px;
 }
-.table{
+
+.table {
     margin-left: 30px;
     margin-right: 30px;
+}
+
+.center {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
 }


### PR DESCRIPTION
Fixes #350

Changes: Simple css added.

Surge Deployment Link: https://pr-378-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43353226-64efe102-9250-11e8-8908-1d1878d367af.png)
