### PR TITLE
Display device info of users on users tab

### DIFF
--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -128,6 +128,34 @@ export default class ListUser extends Component {
         },
       },
     ];
+
+    this.devicesColumns = [
+      {
+        title: 'Device Name',
+        dataIndex: 'devicename',
+        width: '10%',
+      },
+      {
+        title: 'Mac Id',
+        dataIndex: 'macid',
+        width: '10%',
+      },
+      {
+        title: 'Room',
+        dataIndex: 'room',
+        width: '10%',
+      },
+      {
+        title: 'Latitude',
+        dataIndex: 'latitude',
+        width: '10%',
+      },
+      {
+        title: 'Longitude',
+        dataIndex: 'longitude',
+        width: '10%',
+      },
+    ];
   }
 
   apiCall = () => {
@@ -300,6 +328,18 @@ export default class ListUser extends Component {
         let userList = response.users;
         let users = [];
         userList.map((data, i) => {
+          let devices = [];
+          let keys = Object.keys(data.devices);
+          keys.forEach(j => {
+            let device = {
+              macid: j,
+              devicename: data.devices[j].name,
+              room: data.devices[j].room,
+              latitude: data.devices[j].geolocation.latitude,
+              longitude: data.devices[j].geolocation.longitude,
+            };
+            devices.push(device);
+          });
           let user = {
             serialNum: ++i + (page - 1) * 50,
             email: data.name,
@@ -308,6 +348,7 @@ export default class ListUser extends Component {
             lastLogin: data.lastLoginTime,
             ipLastLogin: data.lastLoginIP,
             userRole: data.userRole,
+            devices: devices,
           };
 
           if (user.confirmed) {
@@ -478,7 +519,17 @@ export default class ListUser extends Component {
                       <LocaleProvider locale={enUS}>
                         <Table
                           columns={this.columns}
-                          rowKey={record => record.registered}
+                          rowKey={record => record.serialNum}
+                          expandedRowRender={record => (
+                            <Table
+                              style={{ width: '80%', backgroundColor: 'white' }}
+                              columns={this.devicesColumns}
+                              dataSource={record.devices}
+                              pagination={false}
+                              locale={{ emptyText: 'No devices found!' }}
+                              bordered
+                            />
+                          )}
                           dataSource={this.state.data}
                           pagination={this.state.pagination}
                           loading={this.state.loading}


### PR DESCRIPTION
Fixes #372 

Changes: Display device info of users on users tab

**To review** Go to page 14 of the table to see live preview of akshat's devices

Surge Deployment Link: https://pr-380-fossasia-susi-accounts.surge.sh

Screenshots for the change: 
![d1](https://user-images.githubusercontent.com/30981465/43363031-32890bd0-9318-11e8-95c6-08939d1ab57d.png)
