### PR TITLE
Improved styling of different tab headings in Admin Panel

### DIFF
--- a/src/components/Admin/Admin.css
+++ b/src/components/Admin/Admin.css
@@ -23,9 +23,12 @@
 }
 
 .h2{
-    padding-top: 65px;
-    margin-left: 21px;
+    padding-top: 72px;
+    margin-left: 23px;
     font-size: 35px;
+    font-family: Helvetica Neue For Number,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,PingFang SC,Hiragino Sans GB,Microsoft YaHei,Helvetica Neue,Helvetica,Arial,sans-serif;
+    color: rgba(0,0,0,.65);
+    font-weight: bold;
 }
 
 .containerPaper{


### PR DESCRIPTION
Fixes #387 

Changes: Improved styling of different tab headings in Admin Panel. This was also done to make it similar with the styling done on the Skill CMS Admin Panel.

Surge Deployment Link: https://pr-388-fossasia-susi-accounts.surge.sh

Screenshots for the change:

Before:
<img width="235" alt="screen shot 2018-07-29 at 12 54 33 pm" src="https://user-images.githubusercontent.com/31135861/43363978-9022a736-932e-11e8-95fc-ec0231a8dc41.png">


After:
<img width="247" alt="screen shot 2018-07-29 at 12 53 52 pm" src="https://user-images.githubusercontent.com/31135861/43363975-87ee6924-932e-11e8-92a2-87bc49069d2d.png">