### PR TITLE
Implement skills stats on admin panel

### DIFF
--- a/src/components/Admin/Admin.css
+++ b/src/components/Admin/Admin.css
@@ -33,3 +33,18 @@
     margin-left: 60px;
     margin-right: 40px;
 }
+
+.flexCard{
+    width: 400px;
+    height: 310px;
+    margin-bottom: 20px;
+    font-size: 18px;
+    font-weight: bold;
+    line-height: 2;
+}
+
+@media screen and (max-width: 520px) {
+  .flexCard {
+    width: 310px;
+  }
+}

--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -8,6 +8,7 @@ import Paper from 'material-ui/Paper';
 import { Card } from 'antd';
 import Tabs from 'antd/lib/tabs';
 import 'antd/lib/tabs/style/index.css';
+import { Avatar } from 'antd';
 import NotFound from './../NotFound/NotFound.react';
 
 import urls from '../../utils/urls';
@@ -23,7 +24,9 @@ class Admin extends Component {
     this.state = {
       tabPosition: 'top',
       userStats: {},
-      loading: true,
+      skillStats: {},
+      loadingUsers: true,
+      loadingSkills: true,
     };
   }
 
@@ -41,9 +44,28 @@ class Admin extends Component {
       success: function(response) {
         this.setState({
           userStats: response.userStats,
-          loading: false,
+          loadingUsers: false,
         });
         // console.log(response);
+      }.bind(this),
+      error: function(errorThrown) {
+        console.log(errorThrown);
+      },
+    });
+
+    url = `${urls.API_URL}/cms/getSkillList.json?access_token=${cookies.get(
+      'loggedIn',
+    )}`;
+    $.ajax({
+      url: url,
+      dataType: 'jsonp',
+      jsonp: 'callback',
+      crossDomain: true,
+      success: function(response) {
+        this.setState({
+          skillStats: response.skillStats,
+          loadingSkills: false,
+        });
       }.bind(this),
       error: function(errorThrown) {
         console.log(errorThrown);
@@ -100,51 +122,7 @@ class Admin extends Component {
                       }}
                     >
                       <Card
-                        loading={this.state.loading}
-                        title={
-                          <span
-                            style={{ fontSize: '18px', fontWeight: 'bold' }}
-                          >
-                            Users
-                          </span>
-                        }
-                        style={{
-                          width: '300px',
-                          fontSize: '18px',
-                          fontWeight: 'bold',
-                          lineHeight: '2',
-                        }}
-                      >
-                        <p>
-                          Total :{' '}
-                          {this.state.userStats.totalUsers
-                            ? this.state.userStats.totalUsers
-                            : 0}
-                        </p>
-                        <p>
-                          Active :{' '}
-                          {this.state.userStats.activeUsers
-                            ? this.state.userStats.activeUsers
-                            : 0}
-                        </p>
-                        <p>
-                          Inactive :{' '}
-                          {this.state.userStats.inactiveUsers
-                            ? this.state.userStats.inactiveUsers
-                            : 0}
-                        </p>
-                      </Card>
-                    </span>
-
-                    <span
-                      style={{
-                        fontSize: '18px',
-                        fontWeight: '5000',
-                        float: 'left',
-                      }}
-                    >
-                      <Card
-                        loading={this.state.loading}
+                        loading={this.state.loadingUsers}
                         title={
                           <span
                             style={{ fontSize: '18px', fontWeight: 'bold' }}
@@ -154,6 +132,8 @@ class Admin extends Component {
                         }
                         style={{
                           width: '300px',
+                          height: '310px',
+                          marginBottom: '20px',
                           fontSize: '18px',
                           fontWeight: 'bold',
                           lineHeight: '2',
@@ -193,6 +173,206 @@ class Admin extends Component {
                           Super Admins :{' '}
                           {this.state.userStats.superAdmins
                             ? this.state.userStats.superAdmins
+                            : 0}
+                        </p>
+                      </Card>
+                    </span>
+
+                    <span
+                      style={{
+                        fontSize: '18px',
+                        fontWeight: '5000',
+                        float: 'left',
+                        marginRight: '20px',
+                      }}
+                    >
+                      <Card
+                        className="flexCard"
+                        loading={this.state.loadingUsers}
+                        title={
+                          <span
+                            style={{ fontSize: '18px', fontWeight: 'bold' }}
+                          >
+                            Users
+                          </span>
+                        }
+                      >
+                        <span
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            marginTop: '50px',
+                          }}
+                        >
+                          <span>
+                            <p>Total</p>
+                            <Avatar
+                              style={{
+                                backgroundColor: 'orange',
+                                verticalAlign: 'middle',
+                                marginLeft: '2px',
+                              }}
+                              size="large"
+                              shape="square"
+                            >
+                              {' '}
+                              {this.state.userStats.totalUsers
+                                ? this.state.userStats.totalUsers
+                                : 0}
+                            </Avatar>
+                          </span>
+                          <span>
+                            <p>Active</p>
+                            <Avatar
+                              style={{
+                                backgroundColor: 'green',
+                                verticalAlign: 'middle',
+                                marginLeft: '7px',
+                              }}
+                              size="large"
+                              shape="square"
+                            >
+                              {this.state.userStats.activeUsers
+                                ? this.state.userStats.activeUsers
+                                : 0}
+                            </Avatar>
+                          </span>
+                          <span>
+                            <p>Inactive</p>
+                            <Avatar
+                              style={{
+                                backgroundColor: 'red',
+                                verticalAlign: 'middle',
+                                marginLeft: '13px',
+                              }}
+                              size="large"
+                              shape="square"
+                            >
+                              {' '}
+                              {this.state.userStats.inactiveUsers
+                                ? this.state.userStats.inactiveUsers
+                                : 0}
+                            </Avatar>
+                          </span>
+                        </span>
+                      </Card>
+                    </span>
+
+                    <span
+                      style={{
+                        fontSize: '18px',
+                        fontWeight: '5000',
+                        float: 'left',
+                        marginRight: '20px',
+                      }}
+                    >
+                      <Card
+                        className="flexCard"
+                        loading={this.state.loadingSkills}
+                        title={
+                          <span
+                            style={{ fontSize: '18px', fontWeight: 'bold' }}
+                          >
+                            Skills
+                          </span>
+                        }
+                      >
+                        <span
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            marginTop: '50px',
+                          }}
+                        >
+                          <span>
+                            <p>Total</p>
+                            <Avatar
+                              style={{
+                                backgroundColor: 'orange',
+                                verticalAlign: 'middle',
+                                marginLeft: '2px',
+                              }}
+                              size="large"
+                              shape="square"
+                            >
+                              {this.state.skillStats.totalSkills
+                                ? this.state.skillStats.totalSkills
+                                : 0}
+                            </Avatar>
+                          </span>
+                          <span>
+                            <p>Reviewed</p>
+                            <Avatar
+                              style={{
+                                backgroundColor: 'green',
+                                verticalAlign: 'middle',
+                                marginLeft: '25px',
+                              }}
+                              size="large"
+                              shape="square"
+                            >
+                              {this.state.skillStats.reviewedSkills
+                                ? this.state.skillStats.reviewedSkills
+                                : 0}
+                            </Avatar>
+                          </span>
+                          <span>
+                            <p>Not Reviewed</p>
+                            <Avatar
+                              style={{
+                                backgroundColor: 'red',
+                                verticalAlign: 'middle',
+                                marginLeft: '45px',
+                              }}
+                              size="large"
+                              shape="square"
+                            >
+                              {' '}
+                              {this.state.skillStats.nonReviewedSkills
+                                ? this.state.skillStats.nonReviewedSkills
+                                : 0}
+                            </Avatar>
+                          </span>
+                        </span>
+                      </Card>
+                    </span>
+
+                    <span
+                      style={{
+                        fontSize: '18px',
+                        fontWeight: '5000',
+                        float: 'left',
+                        marginRight: '20px',
+                      }}
+                    >
+                      <Card
+                        loading={this.state.loadingSkills}
+                        title={
+                          <span
+                            style={{ fontSize: '18px', fontWeight: 'bold' }}
+                          >
+                            Skill Types
+                          </span>
+                        }
+                        style={{
+                          width: '300px',
+                          height: '310px',
+                          marginBottom: '20px',
+                          fontSize: '18px',
+                          fontWeight: 'bold',
+                          lineHeight: '2',
+                        }}
+                      >
+                        <p>
+                          Editable :{' '}
+                          {this.state.skillStats.editableSkills
+                            ? this.state.skillStats.editableSkills
+                            : 0}
+                        </p>
+                        <p>
+                          Non Editable :{' '}
+                          {this.state.skillStats.nonEditableSkills
+                            ? this.state.skillStats.nonEditableSkills
                             : 0}
                         </p>
                       </Card>


### PR DESCRIPTION
Fixes #385 

Changes:
- Implement skills stats on admin panel
- Made users card similar to skills card

Surge Deployment Link: https://pr-390-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![s1](https://user-images.githubusercontent.com/30981465/43536129-7242608c-95d9-11e8-9b2f-608277ff22d6.png)