### PR TITLE
Changed dropdowns to checkbox while changing status of any Skill from Admin panel

### DIFF
--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -5,8 +5,7 @@ import { LocaleProvider } from 'antd';
 import enUS from 'antd/lib/locale-provider/en_US';
 import FlatButton from 'material-ui/FlatButton';
 import Dialog from 'material-ui/Dialog';
-import DropDownMenu from 'material-ui/DropDownMenu';
-import MenuItem from 'material-ui/MenuItem';
+import Checkbox from 'material-ui/Checkbox';
 import CircularProgress from 'material-ui/CircularProgress';
 import Snackbar from 'material-ui/Snackbar';
 import Paper from 'material-ui/Paper';
@@ -342,13 +341,15 @@ class ListSkills extends React.Component {
     }
   };
 
-  handleReviewStatusChange = (event, index, value) => {
+  handleReviewStatusChange = () => {
+    let value = !this.state.skillReviewStatus;
     this.setState({
       skillReviewStatus: value,
     });
   };
 
-  handleEditStatusChange = (event, index, value) => {
+  handleEditStatusChange = () => {
+    let value = !this.state.skillEditStatus;
     this.setState({
       skillEditStatus: value,
     });
@@ -403,10 +404,6 @@ class ListSkills extends React.Component {
         onTouchTap={this.handleClose}
       />,
     ];
-
-    const blueThemeColor = { color: 'rgb(66, 133, 244)' };
-    const themeForegroundColor = '#272727';
-    const themeBackgroundColor = '#fff';
 
     const tabStyle = {
       width: '100%',
@@ -622,78 +619,45 @@ class ListSkills extends React.Component {
                           >
                             <TabPane tab="Active" key="1">
                               <Dialog
-                                title="Skill Settings"
+                                title={
+                                  'Skill Settings for ' + this.state.skillName
+                                }
                                 actions={actions}
                                 model={true}
                                 open={this.state.showDialog}
+                                style={{
+                                  width: '800px',
+                                  left: '50%',
+                                  marginLeft: '-400px',
+                                }}
                               >
                                 <div>
-                                  Change the review status of skill{' '}
-                                  {this.state.skillName}
-                                </div>
-                                <div>
-                                  <DropDownMenu
-                                    selectedMenuItemStyle={blueThemeColor}
-                                    onChange={this.handleReviewStatusChange}
-                                    value={this.state.skillReviewStatus}
-                                    labelStyle={{ color: themeForegroundColor }}
-                                    menuStyle={{
-                                      backgroundColor: themeBackgroundColor,
-                                    }}
-                                    menuItemStyle={{
-                                      color: themeForegroundColor,
-                                    }}
+                                  <Checkbox
+                                    label="Reviewed"
+                                    labelPosition="right"
+                                    className="select"
+                                    checked={this.state.skillReviewStatus}
+                                    labelStyle={{ fontSize: '14px' }}
+                                    iconStyle={{ left: '4px', fill: '#4285f4' }}
                                     style={{
-                                      width: '250px',
-                                      marginLeft: '-20px',
+                                      width: 'auto',
+                                      marginTop: '3px',
                                     }}
-                                    autoWidth={false}
-                                  >
-                                    <MenuItem
-                                      primaryText="Approved"
-                                      value={true}
-                                      className="setting-item"
-                                    />
-                                    <MenuItem
-                                      primaryText="Not Approved"
-                                      value={false}
-                                      className="setting-item"
-                                    />
-                                  </DropDownMenu>
-                                </div>
-                                <div style={{ marginTop: '12px' }}>
-                                  Change the edit status of skill{' '}
-                                  {this.state.skillName}
-                                </div>
-                                <div>
-                                  <DropDownMenu
-                                    selectedMenuItemStyle={blueThemeColor}
-                                    onChange={this.handleEditStatusChange}
-                                    value={this.state.skillEditStatus}
-                                    labelStyle={{ color: themeForegroundColor }}
-                                    menuStyle={{
-                                      backgroundColor: themeBackgroundColor,
-                                    }}
-                                    menuItemStyle={{
-                                      color: themeForegroundColor,
-                                    }}
+                                    onCheck={this.handleReviewStatusChange}
+                                  />
+                                  <Checkbox
+                                    label="Editable"
+                                    labelPosition="right"
+                                    className="select"
+                                    checked={this.state.skillEditStatus}
+                                    labelStyle={{ fontSize: '14px' }}
+                                    iconStyle={{ left: '4px', fill: '#4285f4' }}
                                     style={{
-                                      width: '250px',
-                                      marginLeft: '-20px',
+                                      width: 'auto',
+                                      marginTop: '3px',
                                     }}
-                                    autoWidth={false}
-                                  >
-                                    <MenuItem
-                                      primaryText="Editable"
-                                      value={true}
-                                      className="setting-item"
-                                    />
-                                    <MenuItem
-                                      primaryText="Not Editable"
-                                      value={false}
-                                      className="setting-item"
-                                    />
-                                  </DropDownMenu>
+                                    onCheck={this.handleEditStatusChange}
+                                  />
                                 </div>
                               </Dialog>
 


### PR DESCRIPTION
Fixes #394

Changes: Changed dropdowns to checkbox while changing status of any Skill from Admin panel.
Corresponding PR on CMS: https://github.com/fossasia/susi_skill_cms/pull/1392

Surge Deployment Link: https://pr-408-fossasia-susi-accounts.surge.sh

Screenshots for the change:
<img width="1440" alt="screen shot 2018-08-03 at 6 10 07 pm" src="https://user-images.githubusercontent.com/31135861/43643296-7d13909c-9748-11e8-972c-fc9c711199cb.png">
NOTE: Issue of non-standard blue color is already being taken care in https://github.com/fossasia/accounts.susi.ai/pull/397
