### PR TITLE
Displayed number of Staff Picks in the Skill Types card in Admin Panel

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -377,6 +377,12 @@ class Admin extends Component {
                             ? this.state.skillStats.nonEditableSkills
                             : 0}
                         </p>
+                        <p>
+                          Staff Picks :{' '}
+                          {this.state.skillStats.staffPicks
+                            ? this.state.skillStats.staffPicks
+                            : 0}
+                        </p>
                       </Card>
                     </span>
                   </TabPane>


### PR DESCRIPTION
Fixes #420 

Changes: Displayed number of `Staff Picks` in the `Skill Types` card in Admin Panel.

Surge Deployment Link: https://pr-423-fossasia-susi-accounts.surge.sh

Screenshots for the change:
<img width="301" alt="screen shot 2018-08-07 at 9 47 39 pm" src="https://user-images.githubusercontent.com/31135861/43788647-96f2be84-9a8b-11e8-9798-227c290a6e8f.png">
