### PR TITLE
Remove extra padding from search bar

### DIFF
--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -684,7 +684,11 @@ export default class ListUser extends Component {
 
                       <Search
                         placeholder="Search by email"
-                        style={{ margin: '5px 25% 20px 25%', width: '50%' }}
+                        style={{
+                          margin: '5px 25% 20px 25%',
+                          width: '50%',
+                          display: 'flex',
+                        }}
                         size="default"
                         onSearch={value => this.handleSearch(value)}
                       />


### PR DESCRIPTION
Fixes #430 

Changes: Remove extra padding from search bar

Surge Deployment Link: https://pr-438-fossasia-susi-accounts.surge.sh

Screenshots for the change:
Now:
![s1](https://user-images.githubusercontent.com/30981465/43918313-5439f156-9c30-11e8-8e59-3c1d2f134a18.png)
Before:
![s2](https://user-images.githubusercontent.com/30981465/43918179-fb480ce0-9c2f-11e8-9da7-167f5a8c0603.png)
