### PR TITLE
Consistent styling in all dialog boxes in Admin Panel

### DIFF
--- a/src/components/Admin/ListSkills/ListSkills.css
+++ b/src/components/Admin/ListSkills/ListSkills.css
@@ -12,6 +12,10 @@
     margin-right: 30px;
 }
 
+.skillName{
+	font-weight: bold;
+}
+
 .center {
     display: flex;
     align-items: center;

--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -706,7 +706,9 @@ class ListSkills extends React.Component {
                             >
                               <div>
                                 Are you sure you want to delete{' '}
-                                {this.state.skillName}?
+                                <span className="skillName">
+                                  {this.state.skillName}
+                                </span>?
                               </div>
                             </Dialog>
                             <Dialog
@@ -717,7 +719,9 @@ class ListSkills extends React.Component {
                             >
                               <div>
                                 Are you sure you want to restore{' '}
-                                {this.state.skillName}?
+                                <span className="skillName">
+                                  {this.state.skillName}
+                                </span>?
                               </div>
                             </Dialog>
                             <Dialog
@@ -736,13 +740,8 @@ class ListSkills extends React.Component {
                               open={this.state.restoreSuccessDialog}
                             >
                               <div>
-                                You successfully restored
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
+                                You successfully restored{' '}
+                                <span className="skillName">
                                   {this.state.skillName}
                                 </span>
                                 !
@@ -764,13 +763,8 @@ class ListSkills extends React.Component {
                               open={this.state.restoreFailureDialog}
                             >
                               <div>
-                                Error!
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
+                                Error!{' '}
+                                <span className="skillName">
                                   {this.state.skillName}
                                 </span>
                                 could not be restored!
@@ -792,13 +786,8 @@ class ListSkills extends React.Component {
                               open={this.state.deleteSuccessDialog}
                             >
                               <div>
-                                You successfully deleted
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
+                                You successfully deleted{' '}
+                                <span className="skillName">
                                   {this.state.skillName}
                                 </span>
                                 !
@@ -820,13 +809,8 @@ class ListSkills extends React.Component {
                               open={this.state.deleteFailureDialog}
                             >
                               <div>
-                                Error!
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
+                                Error!{' '}
+                                <span className="skillName">
                                   {this.state.skillName}
                                 </span>
                                 could not be deleted!
@@ -849,15 +833,10 @@ class ListSkills extends React.Component {
                               open={this.state.changeStatusSuccessDialog}
                             >
                               <div>
-                                Status of
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
+                                Status of{' '}
+                                <span className="skillName">
                                   {this.state.skillName}
-                                </span>
+                                </span>{' '}
                                 has been changed successfully!
                               </div>
                             </Dialog>
@@ -877,13 +856,8 @@ class ListSkills extends React.Component {
                               open={this.state.changeStatusFailureDialog}
                             >
                               <div>
-                                Error! Status of
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
+                                Error! Status of{' '}
+                                <span className="skillName">
                                   {this.state.skillName}
                                 </span>
                                 could not be changed!


### PR DESCRIPTION
Fixes #443 

Changes: Consistent styling in all dialog boxes in Admin Panel.
Corresponding PR on Skill CMS: https://github.com/fossasia/susi_skill_cms/pull/1531

Surge Deployment Link: https://pr-453-fossasia-susi-accounts.surge.sh

Screenshots for the change:

Before:
<img width="770" alt="screen shot 2018-08-12 at 8 36 05 am" src="https://user-images.githubusercontent.com/31135861/43998217-00dcf32a-9e0e-11e8-8f3b-fe3a0f2f81f4.png">

After:
<img width="771" alt="screen shot 2018-08-12 at 8 58 38 am" src="https://user-images.githubusercontent.com/31135861/43998218-06a1a828-9e0e-11e8-86e8-5ffac52c6bca.png">