### PR TITLE
Fixes #471: Prevent display of cached avatar image

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.js
+++ b/src/components/StaticAppBar/StaticAppBar.js
@@ -107,12 +107,14 @@ class StaticAppBar extends Component {
   render() {
     const isLoggedIn = !!cookies.get('loggedIn');
     let avatarProps = null;
+    const date = new Date();
+    const timestamp = date.getTime();
     if (isLoggedIn) {
       avatarProps = {
         name: cookies.get('emailId'),
         src: `${urls.API_URL}/getAvatar.png?access_token=${cookies.get(
           'loggedIn',
-        )}`,
+        )}&q=${timestamp}`,
       };
     }
 


### PR DESCRIPTION
Fixes #471 

Changes:
* Prevent display of cached avatar image

Surge Deployment Link: https://pr-476-fossasia-susi-accounts.surge.sh
