### PR TITLE
Decrease padding with screen size decrease

### DIFF
--- a/src/components/Auth/ForgotPassword/ForgotPassword.css
+++ b/src/components/Auth/ForgotPassword/ForgotPassword.css
@@ -22,3 +22,9 @@
   user-select: none;
   -webkit-user-select: none;
 }
+
+@media screen and (max-width: 490px) {
+	.forgotPwdForm {
+		padding: 65px 15px;
+	}
+}


### PR DESCRIPTION
Fixes #477 

Changes:
- Decrease padding of forgot password form's container div when the screen size is less then 490px.

Surge Deployment Link: https://pr-478-fossasia-susi-accounts.surge.sh

Screenshots for the change:

![screenshot 25](https://user-images.githubusercontent.com/27884543/44625050-9479f880-a91c-11e8-97e6-2ebd2f50b5ae.png)

@anshumanv @akshatnitd @arundhati24 please review this PR.