### PR TITLE
Align Settings Radio Buttons to Right #509

### DIFF
--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -148,7 +148,7 @@ h5 {
 
 .settings-toggle {
   max-width: 5%;
-  float: left;
+  float: right;
   background-color: #fff;
 }
 .color-box{


### PR DESCRIPTION
Fixes #509
Due to confusion from https://github.com/fossasia/accounts.susi.ai/pull/479, new PR.
Changes: Align radio buttons in settings to right

Surge Deployment Link: https://pr-509-fossasia-susi-accounts.surge.sh

Screenshots for the change:

**Before**

<img width="430" alt="screen shot 2018-09-19 at 6 37 27 pm" src="https://user-images.githubusercontent.com/18073126/45755859-13710100-bc3d-11e8-9ef6-93f15ddf86f4.png">

**After**

<img width="586" alt="screen shot 2018-09-19 at 6 48 56 pm" src="https://user-images.githubusercontent.com/18073126/45755860-14099780-bc3d-11e8-9993-a07f8b417dbd.png">