### PR TITLE
Fixed switch buttons misalignment on decreasing screen size in Speech settings

### DIFF
--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -246,3 +246,9 @@ h5 {
 input[type=file]{
   display: none;
 }
+
+@media screen and (max-width: 500px) {
+  .speechSettingDiv {
+    width: 70%;
+  }
+}

--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -1083,6 +1083,7 @@ class Settings extends Component {
                 float: 'left',
                 padding: '0px 5px 0px 0px',
               }}
+              className="speechSettingDiv"
             >
               Enable speech output only for speech input
             </div>
@@ -1107,6 +1108,7 @@ class Settings extends Component {
                 fontSize: '15px',
                 fontWeight: 'bold',
               }}
+              className="speechSettingDiv"
             >
               Speech Output Always ON
             </div>
@@ -1116,6 +1118,7 @@ class Settings extends Component {
                 float: 'left',
                 padding: '5px 5px 0px 0px',
               }}
+              className="speechSettingDiv"
             >
               Enable speech output regardless of input type
             </div>


### PR DESCRIPTION
Fixes #514 
Changes: When screen size is decreased, the radio buttons aren't misaligned in the speech tab of the settings page.

Surge Deployment Link: https://pr-516-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![screenshot from 2018-09-21 01-03-33](https://user-images.githubusercontent.com/27884543/45842953-d0e21e00-bd3b-11e8-92b5-25f120246a62.png)

@anshumanv @Akshat-Jain @akshatnitd  please review, Thanks!