### PR TITLE
Retain input tags order on resizing

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.css
+++ b/src/components/Auth/ChangePassword/ChangePassword.css
@@ -16,7 +16,6 @@
 }
 
 .forgot {
-  text-align: center;
   margin-top : 20px;
   color : #1DA1F5;
 }
@@ -29,3 +28,4 @@
 .forgot:hover {
   text-decoration: underline;
 }
+

--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -207,6 +207,12 @@ export default class ChangePassword extends Component {
       float: 'left',
       marginTop: '12px',
       marginBottom: '5px',
+      width: '150px',
+    };
+    const submitBtn = {
+      float: 'left',
+      maxWidth: '300px',
+      margin: '0 auto',
     };
     const inputStyle = {
       height: '35px',
@@ -268,19 +274,22 @@ export default class ChangePassword extends Component {
                 />
               </div>
               <br />
-              <div>
-                <RaisedButton
-                  label="Save New Password"
-                  type="submit"
-                  style={{ marginLeft: '30%', marginTop: '0px' }}
-                  backgroundColor={ChatConstants.standardBlue}
-                  labelColor="#fff"
-                />
+              <div style={submitBtn}>
+                <div className="forgot">
+                  <a onClick={this.handleForgotPwd}>Forgot your password?</a>
+                </div>
+                <br />
+                <div>
+                  <RaisedButton
+                    label="Save New Password"
+                    type="submit"
+                    style={{ marginTop: '0px' }}
+                    backgroundColor={ChatConstants.standardBlue}
+                    labelColor="#fff"
+                  />
+                </div>
               </div>
             </form>
-            <div className="forgot">
-              <a onClick={this.handleForgotPwd}>Forgot your password?</a>
-            </div>
           </Paper>
 
           {/* Forgot Password Modal */}


### PR DESCRIPTION
Fixes #515 

Changes: 
Elements of password tab remain in proper order even after resizing

Surge Deployment Link: https://pr-518-fossasia-susi-accounts.surge.sh

Screenshots for the change:

![screen shot 2018-09-21 at 12 05 25 pm](https://user-images.githubusercontent.com/31539812/45864197-d28cff80-bd96-11e8-811b-9c3d86d7f0b4.png)

![resize2](https://user-images.githubusercontent.com/31539812/45864690-7034fe80-bd98-11e8-9ede-5d162815301f.gif)
