### PR TITLE
Edit theme disabled for light/dark

### DIFF
--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -1059,6 +1059,7 @@ class Settings extends Component {
           </RadioButtonGroup>
           <RaisedButton
             label="Edit theme"
+            disabled={this.state.theme !== 'custom'}
             backgroundColor="#4285f4"
             labelColor="#fff"
             onClick={this.handleThemeChanger}


### PR DESCRIPTION
Fixes #525 

Changes: Disabled added in the button edit theme for light/dark theme

Surge Deployment Link: https://pr-526-fossasia-susi-accounts.surge.sh

Screenshots for the change:

![2018-09-23 9](https://user-images.githubusercontent.com/31557923/45928458-aa053100-bf61-11e8-8e6b-d5f1c1b3fcb3.png)

![2018-09-23 10](https://user-images.githubusercontent.com/31557923/45928463-b12c3f00-bf61-11e8-842a-db9a1f6dbe41.png)

