### PR TITLE
Fix : ListUsers query fail error message(snackbar) not showing and loader keeps running

### DIFF
--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -7,6 +7,7 @@ import Table from 'antd/lib/table';
 import { Input } from 'antd';
 import StaticAppBar from '../../StaticAppBar/StaticAppBar.js';
 import FlatButton from 'material-ui/FlatButton';
+import Snackbar from 'material-ui/Snackbar';
 import Dialog from 'material-ui/Dialog';
 import MenuItem from 'material-ui/MenuItem';
 import DropDownMenu from 'material-ui/DropDownMenu';
@@ -33,6 +34,8 @@ export default class ListUser extends Component {
       username: [],
       userEmail: '',
       data: [],
+      openSnackbar: false,
+      msgSnackbar: '',
       middle: '50',
       pagination: {},
       loading: true,
@@ -345,6 +348,7 @@ export default class ListUser extends Component {
       `${urls.API_URL}/aaa/getUsers.json?access_token=` +
       cookies.get('loggedIn') +
       '&getUserCount=true';
+    let self = this;
     $.ajax({
       url: getPagesUrl,
       dataType: 'jsonp',
@@ -355,12 +359,17 @@ export default class ListUser extends Component {
         pagination.total = data.userCount;
         pagination.pageSize = 50;
         pagination.showQuickJumper = true;
-        this.setState({
+        self.setState({
           pagination,
         });
         this.fetch();
       }.bind(this),
       error: function(errorThrown) {
+        self.setState({
+          loading: false,
+          openSnackbar: true,
+          msgSnackbar: "Error. Couldn't fetch users.",
+        });
         console.log(errorThrown);
       },
     });
@@ -865,7 +874,14 @@ export default class ListUser extends Component {
                           </div>
                         </Dialog>
                       </div>
-
+                      <Snackbar
+                        open={this.state.openSnackbar}
+                        message={this.state.msgSnackbar}
+                        autoHideDuration={2000}
+                        onRequestClose={() => {
+                          this.setState({ openSnackbar: false });
+                        }}
+                      />
                       <Search
                         placeholder="Search by email"
                         style={{
@@ -876,7 +892,6 @@ export default class ListUser extends Component {
                         size="default"
                         onSearch={value => this.handleSearch(value)}
                       />
-
                       <LocaleProvider locale={enUS}>
                         {this.state.search ? (
                           <Table


### PR DESCRIPTION
Fixes #527 

Changes: Added snackbar in ListUser screen to show error message of fetch query response. Also stopped running loader(set state to loading : false) after no users were found. 

Minor change : Also in `componentDidMount` when fetch query returns success, `this` was binded. Yet I took a variable(`self`) with `this` binded to actual react class context to support `setState` operation flawlessly in `componentDidMount` method

Surge Deployment Link: https://pr-528-fossasia-susi-accounts.surge.sh/

Screenshots for the change: ![Imgur](https://i.imgur.com/h2zgdZj.png)
