### PR TITLE
Phone number and Country code fields now stay together when screen size is decreased.

### DIFF
--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -1178,7 +1178,14 @@ class Settings extends Component {
                 fontSize: '14px',
               }}
             >
-              Country/region :
+              <div
+                style={{
+                  display: 'inline-block',
+                  width: '101px',
+                }}
+              >
+                Country/region :
+              </div>
               <span style={menuStyle}>
                 <DropDownMenu
                   maxHeight={300}
@@ -1200,17 +1207,26 @@ class Settings extends Component {
             </div>
             <div
               style={{
-                marginTop: '30px',
+                marginTop: '35px',
                 marginBottom: '0px',
                 marginLeft: '0px',
                 fontSize: '14px',
               }}
             >
-              <span style={{ float: 'left' }}>Phone number :</span>
               <span
+                style={{
+                  float: 'left',
+                  marginBottom: '35px',
+                  width: '101px',
+                }}
+              >
+                Phone number :
+              </span>
+              <div
                 style={{
                   width: '250px',
                   marginLeft: '4px',
+                  display: 'inline-block',
                 }}
               >
                 <TextField
@@ -1252,7 +1268,7 @@ class Settings extends Component {
                   errorText={this.state.phoneNoError}
                   floatingLabelText="Phone number"
                 />
-              </span>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes #531 

Changes: On decreasing the screen size, the phone number and country code fields stay together now.
 - Minor change: Also when the screen size is less, the floating label of the phone number field used to coincide with the text, it is also fixed.

Surge Deployment Link: https://pr-532-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![screenshot from 2018-09-28 23-10-38](https://user-images.githubusercontent.com/27884543/46241583-93376200-c3d9-11e8-9e04-74845c44683f.png)

