### PR TITLE
Radio buttons' alignment changed to right

### DIFF
--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -148,7 +148,7 @@ h5 {
 
 .settings-toggle {
   max-width: 5%;
-  float: left;
+  float: right;
   background-color: #fff;
 }
 .color-box{


### PR DESCRIPTION
Fixes #543 

Changes: Radio buttons were toggled to right.

Surge Deployment Link: https://pr-556-fossasia-susi-accounts.surge.sh

Screenshots for the change:

![screenshot 2018-10-25 at 4 18 53 pm](https://user-images.githubusercontent.com/31539812/47495413-b850b080-d871-11e8-99b9-55121be444dc.png)
![screenshot 2018-10-25 at 4 18 43 pm](https://user-images.githubusercontent.com/31539812/47495416-bab30a80-d871-11e8-9793-9c21f73dd65b.png)
![screenshot 2018-10-25 at 4 18 31 pm](https://user-images.githubusercontent.com/31539812/47495418-bc7cce00-d871-11e8-83db-cde69521243a.png)
