### PR TITLE
Maximum limit of allowed password length in password fields added

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -122,10 +122,13 @@ export default class ChangePassword extends Component {
         break;
 
       case 'newPassword':
-        state.newPasswordError = !(state.newPassword.length >= 6);
+        state.newPasswordError = !(
+          state.newPassword.length >= 6 && state.newPassword.length <= 64
+        );
         state.confirmPasswordError = !(value === state.confirmPassword);
         if (state.newPasswordError) {
-          this.newPasswordErrorMessage = 'Minimum 6 characters required';
+          this.newPasswordErrorMessage =
+            'Allowed password length is 6 to 64 characters';
         } else if (state.confirmPasswordError) {
           this.newPasswordErrorMessage = '';
           this.confirmPasswordErrorMessage =

--- a/src/components/Auth/ResetPassword/ResetPassword.react.js
+++ b/src/components/Auth/ResetPassword/ResetPassword.react.js
@@ -148,7 +148,7 @@ class ResetPassword extends Component {
     let state = this.state;
     if (event.target.name === 'newPassword') {
       newPassword = event.target.value;
-      let validPassword = newPassword.length >= 6;
+      let validPassword = newPassword.length >= 6 && newPassword.length <= 64;
       state.newPassword = newPassword;
       state.newPasswordError = !(newPassword && validPassword);
     } else if (event.target.name === 'confirmPassword') {
@@ -168,7 +168,8 @@ class ResetPassword extends Component {
     this.setState(state);
 
     if (this.state.newPasswordError && event.target.name === 'newPassword') {
-      this.newPasswordErrorMessage = 'Minimum 6 characters required';
+      this.newPasswordErrorMessage =
+        'Allowed password length is 6 to 64 characters';
       this.confirmPasswordErrorMessage = '';
     } else if (
       this.state.confirmPasswordError &&

--- a/src/components/Auth/SignUp/SignUp.react.js
+++ b/src/components/Auth/SignUp/SignUp.react.js
@@ -108,7 +108,7 @@ export default class SignUp extends Component {
       emailError = !(email && isEmail);
     } else if (event.target.name === 'password') {
       passwordValue = event.target.value;
-      validPassword = passwordValue.length >= 6;
+      validPassword = passwordValue.length >= 6 && passwordValue.length <= 64;
       passwordError = !(passwordValue && validPassword);
       passwordConfirmError = !(
         passwordValue === this.state.confirmPasswordValue
@@ -123,7 +123,7 @@ export default class SignUp extends Component {
       emailErrorMessage = 'Enter a valid Email Address';
     } else if (passwordError) {
       emailErrorMessage = '';
-      passwordErrorMessage = 'Minimum 6 characters required';
+      passwordErrorMessage = 'Allowed password length is 6 to 64 characters';
       passwordConfirmErrorMessage = '';
       captchaVerifyErrorMessage = '';
     } else if (passwordConfirmError) {


### PR DESCRIPTION
Fixes #581 

Changes: As maximum allowed length of password on server side is 64 characters, upper cap for the same has been added.

Surge Deployment Link: https://pr-582-fossasia-susi-accounts.surge.sh

Screenshots for the change:
GIF-
![ezgif com-video-to-gif 5](https://user-images.githubusercontent.com/31539812/48361680-0403b680-e6c8-11e8-9fd2-7194e67968c7.gif)

