### PR TITLE
Height of nav and the right section is same

### DIFF
--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -82,6 +82,7 @@ body{
 
 .settings-app {
   margin-top:20px;
+  max-height: 500px;
   background-color: #fff;
 }
 
@@ -90,6 +91,7 @@ body{
   width:598.5px;
   min-height:500px;
   height: fit-content;
+  max-height: inherit;
   float:right;
   background-color: #fff;
 }


### PR DESCRIPTION
Fixes #600 

Changes: Height of right section and nav-bar on settings page is same.

Surge Deployment Link: https://pr-601-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![page](https://user-images.githubusercontent.com/32234926/49492166-38a8ff00-f87d-11e8-83b0-64ceff271d3a.PNG)
![height](https://user-images.githubusercontent.com/32234926/49492170-3ba3ef80-f87d-11e8-9443-989aeb273954.PNG)
