### PR TITLE
[chore] fix inconsistent component state updates found by LGTM

### DIFF
--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -423,12 +423,11 @@ class Settings extends Component {
   };
 
   handleRemove = i => {
-    const { obj } = this.state;
-    const macid = obj[i].macid;
+    const macid = this.state.obj[i].macid;
 
-    this.setState({
-      obj: obj.filter((row, j) => j !== i),
-    });
+    this.setState(prevState => ({
+      obj: prevState.obj.filter(row => row.macid !== macid),
+    }));
 
     $.ajax({
       url: `${
@@ -489,10 +488,9 @@ class Settings extends Component {
 
   handleChange = (e, name, i) => {
     const value = e.target.value;
-    const { obj } = this.state;
-    this.setState({
-      obj: obj.map((row, j) => (j === i ? { ...row, [name]: value } : row)),
-    });
+    this.setState(prevState => ({
+      obj: prevState.obj.map((row, j) => (j === i ? { ...row, [name]: value } : row)),
+    }));
   };
 
   handleTabSlide = value => {

--- a/src/components/TableComplex/RemoveDeviceDialog.react.js
+++ b/src/components/TableComplex/RemoveDeviceDialog.react.js
@@ -101,11 +101,10 @@ class RemoveDeviceDialog extends Component {
   };
 
   handleDeviceNameChange = event => {
-    const { devicename } = this.props;
-    this.setState({
+    this.setState((state, props) => ({
       devicename: event.target.value,
-      correctName: event.target.value === devicename,
-    });
+      correctName: event.target.value === props.devicename,
+    }));
   };
 
   render() {


### PR DESCRIPTION
I'm unsure if these are the kinds of contributions that you accept, but I found a couple of cases of inconsistent state changes in react components.

React component state updates using `setState` may asynchronously update `this.props` and `this.state`, thus it is not safe to use either of the two when calculating the new state passed to `setState`, and instead the callback-based variant should be used instead. ([details here](https://lgtm.com/rules/1819283066/)).

These were all found on LGTM.com, and there are [a bunch of other alerts](https://lgtm.com/projects/g/fossasia/accounts.susi.ai/alerts) for this project that would probably also be good to fix.

*(Full disclosure: I'm part of the team behind LGTM.com)*