### PR TITLE
proper responsive on settings page

### DIFF
--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -34,7 +34,7 @@ body{
 }
 
 .setting-item{
-  width:97%;
+  width: 322px;
 }
 
 .Link a {
@@ -185,6 +185,10 @@ h5 {
 
   .settings-list{
     display: none;
+  }
+
+  .setting-item{
+    width: 100%;
   }
 
   .settings-list-dropdown{


### PR DESCRIPTION
Fixes #589

Changes: The width of the settings list is the same when the width of the window is varied.

Surge Deployment Link: https://pr-606-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![responsive](https://user-images.githubusercontent.com/32234926/49689520-43e37f80-fb48-11e8-8b24-c696dc1448a0.gif)
