### PR TITLE
Minimum password length warning removed 

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -106,9 +106,9 @@ export default class ChangePassword extends Component {
     // eslint-disable-next-line
     switch (event.target.name) {
       case 'currentPassword':
-        state.currentPasswordError = !(state.currentPassword.length >= 6);
+        state.currentPasswordError = !state.currentPassword;
         this.currentPasswordErrorMessage = state.currentPasswordError
-          ? 'Minimum 6 characters required'
+          ? 'Password field cannot be blank'
           : '';
         break;
 

--- a/src/components/Auth/DeleteAccount/DeleteAccount.react.js
+++ b/src/components/Auth/DeleteAccount/DeleteAccount.react.js
@@ -75,11 +75,10 @@ class DeleteAccount extends Component {
     let password;
     let state = this.state;
     password = event.target.value;
-    let validPassword = password.length >= 6;
     state.password = password;
-    state.passwordError = !(password && validPassword);
+    state.passwordError = !password;
     if (this.state.passwordError) {
-      this.passwordErrorMessage = 'Minimum 6 characters required';
+      this.passwordErrorMessage = 'Password field cannot be blank';
       state.validForm = false;
     } else {
       this.passwordErrorMessage = '';


### PR DESCRIPTION
Fixes #584 

Changes: Minimum password length warning removed from where it is not required.

Surge Deployment Link: https://pr-608-fossasia-susi-accounts.surge.sh

Screenshots for the change:
GIF-
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/31539812/49715955-27defb80-fc78-11e8-9188-743008800f5a.gif)
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/31539812/49715960-30373680-fc78-11e8-84d6-d9c165dfe891.gif)
