### PR TITLE
SUSI logo is properly aligned in footer

### DIFF
--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -69,10 +69,11 @@ li{
 }
 .susi-logo{
     margin: 21px 10px 0;
-    height: 30px;
+    height: 10px;
     vertical-align: middle;
     max-width: 100px;
     display: inline-block;
+    width: auto;
 }
 
 @media only screen and (min-width: 1400px){
@@ -112,7 +113,9 @@ li{
         display: block;
     }
    .susi-logo{
-    margin-bottom: 9px;
+        display: block;
+        margin-left:auto;
+        margin-right: auto;
    }
 }
 @media only screen and (max-width: 386px){

--- a/src/components/Settings/PreviewThemeChat.css
+++ b/src/components/Settings/PreviewThemeChat.css
@@ -41,11 +41,6 @@
     height: 30px;
     justify-content: space-between;
 }
-.susi-logo{
-    width:50px;
-    height: 10px;
-    margin-left:10px;
-}
 .chat-input-send{
     cursor: pointer;
 }


### PR DESCRIPTION
Fixes #503 

Changes: SUSI logo is properly aligned in the center when screen size is varied, which makes it consistent with the footer of chat.susi.ai

Surge Deployment Link: https://pr-${TRAVIS_PULL_REQUEST}-fossasia-susi-accounts.surge.sh

Screenshots for the change:
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/31539812/49862641-9d87ca80-fe24-11e8-9701-20b698c37316.gif)
