### PR TITLE
Placeholer in change password form text changed

### DIFF
--- a/src/components/Auth/ChangePassword/ChangePassword.react.js
+++ b/src/components/Auth/ChangePassword/ChangePassword.react.js
@@ -220,7 +220,7 @@ export default class ChangePassword extends Component {
               <div>
                 <PasswordField
                   name="newPassword"
-                  placeholder="Must be at least 6 characters"
+                  placeholder="Must be from 6 to 64 characters"
                   style={fieldStyle}
                   value={this.state.newPassword}
                   onChange={this.handleChange}


### PR DESCRIPTION
Fixes #633 

Changes: Placeholder text changed to `Must be from 6 to 64 characters`

Surge Deployment Link: https://pr-634-fossasia-susi-accounts.surge.sh

Screenshots for the change:

![screenshot 2018-12-23 at 12 26 39 pm](https://user-images.githubusercontent.com/31539812/50381501-a4c59880-06ae-11e9-9632-e10793ce6788.png)

