### PR TITLE
forgotPassword: modify responsiveness for small screen devices

### DIFF
--- a/src/components/Auth/ForgotPassword/ForgotPassword.css
+++ b/src/components/Auth/ForgotPassword/ForgotPassword.css
@@ -1,12 +1,12 @@
 .forgotPwdForm {
-	width: 270px;
-	margin: 0 auto;
+  width: 270px;
+  margin: 0 auto;
 }
 
 .forgotPwdContainer {
-	display: flex;
-	flex-direction: column;
-	height: 100vh;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
 }
 
 .modalDiv > div > div > div {
@@ -14,14 +14,21 @@
   margin: 0px auto;
 }
 
+@media screen and (max-width : 783px) {
+  .modalDiv > div > div > div {
+    width: 80%;
+    margin: 0px auto;
+  }
+}
+
 @media screen and (max-width: 768px) {
-	.forgotPwdForm h1{
-		font-size: 16px;
-	}
-	.forgotPwdForm {
-		width: 320px;
-		margin: 0 auto;
-	}
+  .forgotPwdForm h1{
+    font-size: 16px;
+  }
+  .forgotPwdForm {
+    width: unset;
+    margin: 0 auto;
+  }
 }
 .app-bar-div{
   position: fixed;
@@ -35,14 +42,21 @@
 }
 
 @media screen and (max-width: 490px) {
-	.forgotPwdForm {
-		padding: 65px 15px;
-	}
+  .forgotPwdForm {
+    padding: 2em 1px;
+  }
 }
-
-@media screen and (max-width : 783px) {
+@media screen and (max-width: 460px) {
   .modalDiv > div > div > div {
-    width: 80%;
+    width: 100%;
     margin: 0px auto;
+  }
+}
+@media screen and (max-width: 362px) {
+  .forgotPwdForm {
+    padding: 2em 0;
+  }
+  .modalDiv>div>div {
+    width: 95% !important; /* csslint allow: known-properties, important */
   }
 }

--- a/src/components/Auth/ForgotPassword/ForgotPassword.react.js
+++ b/src/components/Auth/ForgotPassword/ForgotPassword.react.js
@@ -155,6 +155,7 @@ class ForgotPassword extends Component {
                 <div>
                   <TextField
                     name="email"
+                    style={{ width: '100%' }}
                     floatingLabelText="Email"
                     errorText={this.emailErrorMessage}
                     value={this.state.email}


### PR DESCRIPTION
Fixes #656 
Changes: Currently the forgot password modal is not responsive for small screen devices. But, it should be responsive.

Surge Deployment Link: https://pr-662-fossasia-susi-accounts.surge.sh

Screenshots for the change:

![image](https://user-images.githubusercontent.com/31389740/50755159-2fe18980-127e-11e9-8a39-a2b147c921f2.png)

