### PR TITLE
make the height of login and signup page consistent

### DIFF
--- a/src/components/Auth/SignUp/SignUp.css
+++ b/src/components/Auth/SignUp/SignUp.css
@@ -50,6 +50,7 @@
   width : 50%;
   float : left;
   background-color : #EEE;
+  min-height: 100vh;
 }
 
 .About{
@@ -222,7 +223,10 @@
     float : none;
     height: auto;
     width : auto;
-	}
+  }
+  .app-body {
+    min-height: unset;
+  }
   .app-body-div{
     height:auto;
     width : auto;


### PR DESCRIPTION
Fixes #686 

Changes: Currently height of login and signup page falls short on large devices. But it should take up the complete space.

Surge Deployment Link: https://pr-${TRAVIS_PULL_REQUEST}-fossasia-susi-accounts.surge.sh

Screenshots for the change:

![image](https://user-images.githubusercontent.com/31389740/51441387-eae63a00-1cf6-11e9-9fa6-2ca45b13e417.png)

