### PR TITLE
ProtectedRoute: prevent unwanted redirect

### DIFF
--- a/src/components/ProtectedRoute/ProtectedRoute.js
+++ b/src/components/ProtectedRoute/ProtectedRoute.js
@@ -1,24 +1,15 @@
 import Cookies from 'universal-cookie';
 import React from 'react';
-import { Route, Redirect } from 'react-router-dom';
+import { Route } from 'react-router-dom';
+import NotFound from '../NotFound/NotFound.react';
+
 const cookies = new Cookies();
 export default function ProtectedRoute({ component: Component, ...rest }) {
   const isLoggedIn = !!cookies.get('loggedIn');
   return (
     <Route
       {...rest}
-      render={props =>
-        isLoggedIn ? (
-          <Component {...props} />
-        ) : (
-          <Redirect
-            to={{
-              pathname: '/error-404',
-              state: { from: props.location },
-            }}
-          />
-        )
-      }
+      render={props => (isLoggedIn ? <Component {...props} /> : <NotFound />)}
     />
   );
 }


### PR DESCRIPTION
Fixes #694 

Changes: Currently, in ProtectedRoute component, when the user is not logged in, it is redirecting to /error-404. Instead, it should display not found for that page.

Surge Deployment Link: https://pr-695-fossasia-susi-accounts.surge.sh

Screenshots for the change:

![image](https://user-images.githubusercontent.com/31389740/51610673-515f9800-1f43-11e9-8254-6e499f1cfe6e.png)
