### PR TITLE
settings: make menu and description heights consistent

### DIFF
--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -23,7 +23,6 @@ body{
 
 .img-upld {
   width: 50%;
-  padding: 10px;
 }
 
 .navBar {

--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -145,7 +145,7 @@ const AvatarRender = props => {
     case 'server':
       return (
         <form
-          style={{ display: 'inline-block', marginTop: '10px' }}
+          style={{ display: 'inline-block' }}
           onSubmit={e => props.handleAvatarSubmit(e)}
         >
           {props.isAvatarAdded && (
@@ -1723,8 +1723,8 @@ class Settings extends Component {
                   <p
                     style={{
                       textAlign: 'center',
-                      marginTop: '20px',
-                      marginBottom: '20px',
+                      marginTop: '12px',
+                      marginBottom: '0',
                       display: 'flex',
                       justifyContent: 'center',
                     }}


### PR DESCRIPTION
Fixes #718 
Changes: Currently the heights of menu and account description on settings page are uneven. It should be even.

Surge Deployment Link: https://pr-719-fossasia-susi-accounts.surge.sh

Screenshots for the change: [Add here screenshots depicting the change.]

![image](https://user-images.githubusercontent.com/31389740/52837224-de95a700-3113-11e9-9b8f-8386b63c324b.png)
