### PR TITLE
settings: make User Name and Select Avatar heights consistent 

### DIFF
--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -1031,7 +1031,7 @@ class Settings extends Component {
               </div>
             </div>
             <div className="img-upld">
-              <div className="label" style={{ marginBottom: '0' }}>
+              <div className="label" style={{ marginTop: '0' }}>
                 Select Avatar
               </div>
               <DropDownMenu


### PR DESCRIPTION
Fixes #720 
Changes: Currently the heights of User Name and Select Avatar on settings page are uneven. It should be even.

Surge Deployment Link: https://pr-721-fossasia-susi-accounts.surge.sh
Screenshots for the change:
![incline names](https://user-images.githubusercontent.com/30196269/52851514-55469a80-313c-11e9-9496-52d2968a892c.png)


