### PR TITLE
settings: heights of User Name and Select Avatar is evened in same line

### DIFF
--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -22,8 +22,8 @@ body{
 }
 
 .img-upld {
-  width: 50%;
-  padding: 10px;
+  width: 20%;
+  padding: 0px;
 }
 
 .navBar {

--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -1031,7 +1031,7 @@ class Settings extends Component {
               </div>
             </div>
             <div className="img-upld">
-              <div className="label" style={{ marginTop: '0' }}>
+              <div className="label" style={{ marginBottom: '0' }}>
                 Select Avatar
               </div>
               <DropDownMenu

--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -1031,7 +1031,7 @@ class Settings extends Component {
               </div>
             </div>
             <div className="img-upld">
-              <div className="label" style={{ marginBottom: '0' }}>
+              <div className="label" style={{ marginTop: '0' }}>
                 Select Avatar
               </div>
               <DropDownMenu


### PR DESCRIPTION
Fixes #720 

Changes: Currently the heights of User Name and Select Avatar on settings page are uneven. It should be even.

Surge Deployment Link: https://pr-720-fossasia-susi-accounts.surge.sh

Screenshots for the change: [Add here screenshots depicting the change.]
![incline names](https://user-images.githubusercontent.com/30196269/52902099-f4998980-3231-11e9-8008-94a14abc5e80.png)

