### PR TITLE
Email field clears after clicking on cancel

### DIFF
--- a/src/components/Auth/ForgotPassword/ForgotPassword.react.js
+++ b/src/components/Auth/ForgotPassword/ForgotPassword.react.js
@@ -119,7 +119,8 @@ class ForgotPassword extends Component {
     }
   };
 
-  closeModal = () => this.setState({ forgotPwdDialog: false, msg: '' });
+  closeModal = () =>
+    this.setState({ forgotPwdDialog: false, msg: '', email: '' });
 
   openModal = e => {
     e.preventDefault();


### PR DESCRIPTION
Fixes #723 

Changes: Email field clears itself after the cancel button is clicked.

Surge Deployment Link: https://pr-724-fossasia-susi-accounts.surge.sh



