### PR TITLE
Fix UI bug in Mobile tab in Settings

### DIFF
--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -1446,7 +1446,7 @@ class Settings extends Component {
                       .countryCallingCodes[0]
                   }
                   style={{
-                    width: '45px',
+                    width: '55px',
                     marginTop: '-18px',
                     marginLeft: '30px',
                     float: 'left',


### PR DESCRIPTION
Fixes #734 
Changes: [Add here what changes you made in this Pull Request and if possible provide links referring the changes.]
Increase the width of country code text field in mobile tab in settings.
Surge Deployment Link: https://pr-735-fossasia-susi-accounts.surge.sh

Screenshots for the change: [Add here screenshots depicting the change.]
![Screenshot 2019-04-06 at 11 52 52 PM](https://user-images.githubusercontent.com/31013104/55673616-d8c47280-58c7-11e9-88d6-841c881537f3.png)

